### PR TITLE
Better conversion workflow improvements

### DIFF
--- a/src/bbmods/modelFormatMod.js
+++ b/src/bbmods/modelFormatMod.js
@@ -138,9 +138,7 @@ ModelFormat.prototype.convertTo = function convertTo() {
 	) {
 		Cube.all.forEach((cube) => {
 			if (!cube.rotation.allEqual(0)) {
-				var axis =
-					(cube.rotation_axis && getAxisNumber(cube.rotation_axis)) ||
-					0
+				vvar axis = cube.rotationAxis() ? getAxisNumber(cube.rotationAxis()) : 0;
 				var angle = limitNumber(
 					Math.round(cube.rotation[axis] / 22.5) * 22.5,
 					-45,

--- a/src/bbmods/modelFormatMod.js
+++ b/src/bbmods/modelFormatMod.js
@@ -2,6 +2,7 @@ import * as EVENTS from '../constants/events'
 import { format, format as modelFormat } from '../modelFormat'
 import { bus } from '../util/bus'
 import { wrapNumber } from '../util/misc'
+import * as path from "path/posix"
 
 const oldConvertFunc = ModelFormat.prototype.convertTo
 
@@ -155,10 +156,20 @@ ModelFormat.prototype.convertTo = function convertTo() {
 	Canvas.updateAllFaces()
 	updateSelection()
 
-	// Mark the project as unsaved, so the user can save it and preserve the conversion
-	Project.saved = false
+	// Hides the conversion dialog
+	hideDialog();
 
-	// Hacky method to refresh the top bar and make the custom tab menu appear without reopening the project
+	// Saves the new converted file
+	let fileName = Project.save_path.replace(/\\/g, '/').split('/').pop()
+    	let dirPath = Project.save_path.slice(0, -fileName.length)
+	dirPath = path.normalize(dirPath)
+	Project.export_path = dirPath + Project.name + "." + Project.format.codec.extension
+	Project.format.codec.export()
+
+	// Updates the current project view save_path variable to be equal to the just saved one
+	Project.save_path = Project.export_path
+
+	// Hacky trick to show the ItemsAdder menu on top
 	Interface.tab_bar.openNewTab()
 	ModelProject.all[0].select()
 }

--- a/src/bbmods/modelFormatMod.js
+++ b/src/bbmods/modelFormatMod.js
@@ -3,6 +3,7 @@ import { format, format as modelFormat } from '../modelFormat'
 import { bus } from '../util/bus'
 import { wrapNumber } from '../util/misc'
 import * as path from "path/posix"
+import { settings } from '../settings'
 
 const oldConvertFunc = ModelFormat.prototype.convertTo
 
@@ -18,6 +19,10 @@ ModelFormat.prototype.convertTo = function convertTo() {
 	if (Format.id === format.id) {
 		Project.UUID = guid()
 	}
+	
+	// Set the current projectName
+	settings.animatedJava.projectName = Project.name
+	
 	// Box UV
 	if (!this.optional_box_uv) Project.box_uv = this.box_uv
 

--- a/src/modelComputation.js
+++ b/src/modelComputation.js
@@ -128,7 +128,7 @@ export function computeElements() {
 			} else {
 				element.rotation = new oneLiner({
 					angle: 0,
-					axis: s.rotation_axis || 'y',
+					axis: s.rotationAxis() || 'y',
 					origin: s.origin,
 					rescale: true,
 				})


### PR DESCRIPTION
Better conversion workflow improvements:

- the plugin converts the `.bbmodel` file
- prompts the save dialog and lets the user save the new file with the new codec extension
- refreshes the currently loaded project to reflect the converted one

Init projectName on conversion:
The projectName setting is blank after conversion. I think it's good to set it to the project name itself.

Fix rotation axis calculation:
For some reason I got issues using rotation_axis instead of rotationAxis(), that's why I decided to share this fix.