### PR TITLE
Add support for german (DE)

### DIFF
--- a/exporters/datapackExporter/exporter/translations.ts
+++ b/exporters/datapackExporter/exporter/translations.ts
@@ -1,10 +1,16 @@
 // @ts-ignore
 import en from '../lang/en.yaml'
+// @ts-ignore
+import de from '../lang/de.yaml'
+// @ts-ignore
+import zh from '../lang/zh_cn.yaml'
 
 export function loadTranslations() {
 	const { addTranslations, translate } = AnimatedJava.API
 
 	addTranslations('en', en as Record<string, string>)
+	addTranslations('de', de as Record<string, string>)
+	addTranslations('zh', zh as Record<string, string>)
 
 	return {
 		target_minecraft_version: {

--- a/exporters/datapackExporter/lang/de.yaml
+++ b/exporters/datapackExporter/lang/de.yaml
@@ -1,0 +1,77 @@
+# Animation Exporter
+animated_java.datapack_exporter.name: Datenpaket Exportierer
+
+animated_java.datapack_exporter.settings.target_minecraft_version: Ziel Minecraft-Version
+animated_java.datapack_exporter.settings.target_minecraft_version.description: |-
+    Die Minecraft-Version, in der Sie das Datenpaket verwenden möchten.
+
+animated_java.datapack_exporter.settings.datapack_mcmeta: Datenpaket
+animated_java.datapack_exporter.settings.datapack_mcmeta.description: |-
+    Das Datenpaket, in das die generierten Funktionen eingefügt werden.
+    Dieser Dateipfad sollte die 'pack.mcmeta'-Datei eines gültigen Datenpakets bezeichnen.
+animated_java.datapack_exporter.settings.datapack_mcmeta.error.unset: |-
+    Sie müssen ein Datenpakets-Ordner auswählen
+animated_java.datapack_exporter.settings.datapack_mcmeta.error.invalid: |-
+    Der ausgewählte Pfad ist kein gültiges Datenpaket!
+    Stellen Sie sicher, dass Sie die richtige 'pack.mcmeta'-Datei ausgewählt haben und dass das Datenpaket ein 'data'-Ordner hat.
+
+animated_java.datapack_exporter.settings.interpolation_duration: Interpolation-Dauer
+animated_java.datapack_exporter.settings.interpolation_duration.description: |-
+    Die Dauer (in Ticks), die jedes Keyframe versuchen wird, Änderungen zwischen Keyframes zu glätten.
+    Wenn diese Einstellung höher als 1 ist, wird die Animation flüssiger, verliert aber an Präzision.
+    Bei einem Wert von 0 wird Interpolation deaktiviert.
+
+animated_java.datapack_exporter.settings.enable_outdated_rig_warning: Warnung für veraltetes Rig aktivieren
+animated_java.datapack_exporter.settings.enable_outdated_rig_warning.description: |-
+    Ob eine Warnung im Spiel angezeigt werden soll, wenn ein Rig gefunden wird, das vor dem neuesten Export erschaffen wurde.
+
+animated_java.datapack_exporter.settings.root_entity_nbt: Ursprungsobjekt NBT
+animated_java.datapack_exporter.settings.root_entity_nbt.description: |-
+    Benutzerdefinierte NBT, die beim Ursprungsobjekt angewendet werden soll.
+    Beachten Sie, dass einige interne NBT Vorrang vor dieser Einstellung habn können.
+
+animated_java.datapack_exporter.settings.function_toggles_group: Funktionseinstellungen
+
+animated_java.datapack_exporter.settings.include_variant_summon_functions: Varianten-Beschwörungsfunktionen generieren
+animated_java.datapack_exporter.settings.include_variant_summon_functions.description: |-
+    Ob Funktionen, die Varianten des Rigs erschaffen, exportiert werden sollen.
+    Diese Funktionen sind gleichbedeutend mit dem Setzen von #variant aj.id beim Ausführen der Erschaffungsfunktion.
+
+animated_java.datapack_exporter.settings.include_apply_variant_functions: Varianten-Funktionen generieren
+animated_java.datapack_exporter.settings.include_apply_variant_functions.description: |-
+    Ob Funktionen, die Varienten des Rigs ändern, exportiert werden sollen.
+    Beachten Sie, dass Varianten-Keyframes auch ohne diese Funktionen die Variante ändern können.
+
+animated_java.datapack_exporter.settings.include_uninstall_function: Deinstallationsfunktion generieren
+animated_java.datapack_exporter.settings.include_uninstall_function.description: |-
+    Ob die Funktion, um das Datenpaket zu deinstallieren, exportiert werden soll.
+
+animated_java.datapack_exporter.settings.include_pause_all_animations_function: Funktion 'Alle Animationen Pausieren' generieren
+animated_java.datapack_exporter.settings.include_pause_all_animations_function.description: |-
+    Ob die Funktion 'pause_all_animations' exportiert werden soll.
+
+animated_java.datapack_exporter.settings.include_remove_rigs_function: Funktion 'Rigs Entfernen' generieren
+animated_java.datapack_exporter.settings.include_remove_rigs_function.description: |-
+    Ob die Funktion 'remove/rigs' exportiert werden soll.
+
+animated_java.datapack_exporter.settings.include_remove_all_function: Funktion 'Alles Entfernen' generieren
+animated_java.datapack_exporter.settings.include_remove_all_function.description: |-
+    Ob die Funktion 'remove/all' exportiert werden soll.
+
+animated_java.datapack_exporter.settings.function_tag_toggles_group: Funktions-Tags-Einstellungen
+
+animated_java.datapack_exporter.settings.include_on_load_function_tags: Tag 'on load' generieren
+animated_java.datapack_exporter.settings.include_on_load_function_tags.description: |-
+    Ob die Funktions-Tags 'on_load' exportiert werden sollen.
+
+animated_java.datapack_exporter.settings.include_on_tick_function_tags: Tag 'on tick' generieren
+animated_java.datapack_exporter.settings.include_on_tick_function_tags.description: |-
+    Ob die Funktions-Tags 'on_tick' exportiert werden sollen.
+
+animated_java.datapack_exporter.settings.include_on_summon_function_tags: Tag 'on summon' generieren
+animated_java.datapack_exporter.settings.include_on_summon_function_tags.description: |-
+    Ob die Funktions-Tags 'on_summon' exportiert werden sollen.
+
+animated_java.datapack_exporter.settings.include_on_remove_function_tags: Tag 'on remove' generieren
+animated_java.datapack_exporter.settings.include_on_remove_function_tags.description: |-
+    Ob die Funktions-Tags 'on_remove' exportiert werden sollen.

--- a/exporters/jsonExporter/jsonExporter.ts
+++ b/exporters/jsonExporter/jsonExporter.ts
@@ -1,11 +1,17 @@
 // @ts-ignore
 import en from './lang/en.yaml'
+// @ts-ignore
+import de from './lang/de.yaml'
+// @ts-ignore
+import zh from './lang/zh_cn.yaml'
 import { constructJSON } from './jsonConstructor'
 
 export function loadExporter() {
 	const API = AnimatedJava.API
 
 	API.addTranslations('en', en as Record<string, string>)
+	API.addTranslations('de', de as Record<string, string>)
+	API.addTranslations('zh', zh as Record<string, string>)
 
 	const TRANSLATIONS = {
 		output_file: {

--- a/exporters/jsonExporter/lang/de.yaml
+++ b/exporters/jsonExporter/lang/de.yaml
@@ -1,0 +1,9 @@
+# JSON Exporter
+animated_java.exporters.json_exporter.name: JSON Exporter
+animated_java.exporters.json_exporter.description: Exportiert das Animated Java Rig als eine JSON-Datei für Anwendungen in Plugins oder Mods.
+
+# Settings
+animated_java.exporters.json_exporter.settings.output_file: Exportdatei
+animated_java.exporters.json_exporter.settings.output_file.description: Der Dateipfad für das Exportieren.
+animated_java.exporters.json_exporter.settings.output_file.error.empty: |-
+    Der Dateipfad darf nicht leer sein.

--- a/exporters/jsonExporter/lang/de.yaml
+++ b/exporters/jsonExporter/lang/de.yaml
@@ -1,5 +1,5 @@
 # JSON Exporter
-animated_java.exporters.json_exporter.name: JSON Exporter
+animated_java.exporters.json_exporter.name: JSON Exportierer
 animated_java.exporters.json_exporter.description: Exportiert das Animated Java Rig als eine JSON-Datei für Anwendungen in Plugins oder Mods.
 
 # Settings

--- a/src/lang/de.yaml
+++ b/src/lang/de.yaml
@@ -265,6 +265,7 @@ animated_java.variant_properties.variant_name.error.duplicate_name: |-
 
 animated_java.dialog.variant_properties.affected_bones_is_a_whitelist: Ignorierte Knochen sind eine White-Liste
 animated_java.dialog.variant_properties.affected_bones_is_a_whitelist.description: |-
+    Die Knochen, die diese Variante beeinflussen wird.
     Falls wahr, werden nur Knochen auf der 'Ignorierte Knochen'-Liste von dieser Variante betroffen sein.
     Falls falsch, werden alle Knochen außer denen in der Liste von dieser Variente betroffen sein.
 

--- a/src/lang/de.yaml
+++ b/src/lang/de.yaml
@@ -162,7 +162,7 @@ animated_java.dialog.camera_config: Animated Java Kamera-Konfiguration
 animated_java.camera_config.entity_type: Typ des teleportierten Objektes
 animated_java.camera_config.entity_type.description: |-
     Das Objekt, das beim Erzeugen der Kamera verwendet werden soll.
-    Zum Beispiel, falls Sie `minecraft:armor_stand` einstellen, wird die Kamera im Spiel zu einem armor_stand.
+    Zum Beispiel, falls Sie `minecraft:armor_stand` einstellen, wird die Kamera im Spiel ein armor_stand sein.
 animated_java.camera_config.entity_type.error.space: |-
     Objekt-IDs dürfen keine Leerzeichen enthalten.
 animated_java.camera_config.entity_type.error.invalid_namespace: |-
@@ -178,25 +178,25 @@ animated_java.camera_config.nbt.description: |-
     Beachten Sie, dass einige interne NBT Vorrang vor dieser Einstellung habn können.
 
 ### Locator Config
-animated_java.dialog.locator_config: Animated Java Locator Config
+animated_java.dialog.locator_config: Animated Java Locator-Konfiguration
 
-animated_java.locator_config.entity_type: Entity Type
+animated_java.locator_config.entity_type: Objekt-Typ
 animated_java.locator_config.entity_type.description: |-
-    The entity to use when summoning the locator.
-    For instance, if you set this to `minecraft:pig`, The locator will be a pig in-game.
+    Das Objekt, das beim Erzeugen des Locators verwendet wird.
+    Zum Beispiel, falls Sie `minecraft:pig` einstellen, wird der Locator im Spiel ein Schwein sein.
 animated_java.locator_config.entity_type.error.space: |-
-    Entity IDs cannot contain spaces.
+    Objekt-IDs dürfen keine Leerzeichen enthalten.
 animated_java.locator_config.entity_type.error.invalid_namespace: |-
-    Entity IDs must have a namespace.
+    Objekt-IDs müssen ein Namespace haben.
 animated_java.locator_config.entity_type.warning.unknown_entity: |-
-    Entity ID isn't in vanilla minecraft
-    This may cause issues when exporting.
-    Ignore this warning if you're using snapshots or mods.
+    Objekt existiert nicht in Vanilla Minecraft.
+    Dies könnte Probleme verursachen beim exportieren.
+    Ignorieren Sie diese Warnung, falls Sie Snapshot-Versionen oder mit Mods spielen.
 
 animated_java.locator_config.nbt: NBT
 animated_java.locator_config.nbt.description: |-
-    Custom NBT to apply to the summoned locator entity.
-    Note that some internal NBT tags will take priority over this setting.
+    Benutzerdefinierte NBT, die bei diesem Locator angewendet werden soll.
+    Beachten Sie, dass einige interne NBT Vorrang vor dieser Einstellung habn können.
 
 ### Animation Config
 animated_java.dialog.animation_config.title: Animation Properties

--- a/src/lang/de.yaml
+++ b/src/lang/de.yaml
@@ -356,7 +356,7 @@ animated_java.popup.invalid_cubes.title: Ungültige Form(en)
 animated_java.popup.invalid_cubes.body: |-
     Einige Formen haben ungültige Drehungen!
     Die ungültigen Formen können Sie unten finden, sortiert nach den Knochen, in denen sie sich befinden.
-    Die Formen werden auch in der 3D-Ansicht hervorgehoben, sobald Sie dieses Popup schliessen.
+    Die Formen werden auch in der 3D-Ansicht hervorgehoben, sobald Sie dieses Popup schließen.
 
 # Failed Project Export Readiness
 animated_java.popup.failed_project_export_readiness.title: Export fehlgeschlagen

--- a/src/lang/de.yaml
+++ b/src/lang/de.yaml
@@ -2,152 +2,152 @@ animated_java.title: Animated Java
 
 animated_java.menubar.settings: Animated Java
 
-animated_java.menubar.items.about: About
-animated_java.menubar.items.settings: Settings
-animated_java.menubar.items.project_settings: Project Settings
-animated_java.menubar.items.documentation: Documentation
-animated_java.menubar.items.export_project: Export Project
-animated_java.menubar.items.bone_config: Bone Config
-animated_java.menubar.items.camera_config: Camera Config
-animated_java.menubar.items.locator_config: Locator Config
+animated_java.menubar.items.about: Über...
+animated_java.menubar.items.settings: Einstellungen
+animated_java.menubar.items.project_settings: Projekteinstellungen
+animated_java.menubar.items.documentation: Dokumentation
+animated_java.menubar.items.export_project: Projekt exportieren
+animated_java.menubar.items.bone_config: Knochen-Konfiguration
+animated_java.menubar.items.camera_config: Kamera-Konfiguration
+animated_java.menubar.items.locator_config: Locator-Konfiguration
 
-animated_java.quickmessage.exported_successfully: Project Exported Successfully!
+animated_java.quickmessage.exported_successfully: Export erfolgreich!
 
 ### Dialogs
-animated_java.dialog.close_button: Done
+animated_java.dialog.close_button: Fertig
 
 ### About
-animated_java.dialog.about.title: About Animated Java
+animated_java.dialog.about.title: Über Animated Java
 
 ### Export in Progress
-animated_java.dialog.export_in_progress.title: Exporting Project...
+animated_java.dialog.export_in_progress.title: Export läuft ...
 
 ### Settings
-animated_java.settings.accessability_options_group: Accessability
+animated_java.settings.accessability_options_group: Barrierefreiheit
 
-animated_java.dialog.settings.title: Animated Java Settings
-animated_java.settings.reduced_motion: Reduced Motion
+animated_java.dialog.settings.title: Animated Java Einstellungen
+animated_java.settings.reduced_motion: Reduzierte Bewegungen
 animated_java.settings.reduced_motion.description: |-
-    Disable all UI animations in Animated Java's Menus.
-    This will disable animations and other effects that may cause motion sickness.
+    Deaktivieren Sie alle UI-Animationen in Animated Java Menüs.
+    Dadurch werden Animationen und andere Effekte deaktiviert, die Schwindel verursachen können.
 
 animated_java.settings.resource_pack_group: Resource Pack
 
-animated_java.settings.minify_output: Minify Output
+animated_java.settings.minify_output: Export minimieren
 animated_java.settings.minify_output.description: |-
-    Minify the output of the exported resource pack.
-    This will remove all comments and whitespace from the output.
-    This will make the output smaller, but will make it harder to read.
+    Verkleinert die Ausgabe des exportierten Resource Packs
+    Dabei werden alle Kommentare und Leerzeichen aus dem Export entfernt.
+    Dadurch wird die Ausgabe kleiner, aber schwieriger zu lesen.
 
 ### Documentation
-animated_java.dialog.documentation.title: Animated Java Documentation
+animated_java.dialog.documentation.title: Animated Java Dokumentation
 
-animated_java.dialog.documentation.loading: Loading Documentation...
+animated_java.dialog.documentation.loading: Dokumentation wird geladen ...
 
-animated_java.dialog.documentation.error.failed_to_load.title: Failed to Load Documentation! :(
+animated_java.dialog.documentation.error.failed_to_load.title: Dokumentation konnte nicht geladen werden! :(
 animated_java.dialog.documentation.error.failed_to_load.description: |-
-    Make sure you're connected to the internet!
+    Stellen Sie sicher, dass eine Internetverbindung besteht!
 
 ### Project Settings
-animated_java.dialog.project_settings.title: Animated Java Project Settings
+animated_java.dialog.project_settings.title: Animated Java Projekteinstellungen
 
-animated_java.dialog.project_settings.project_group: Project
+animated_java.dialog.project_settings.project_group: Projekt
 
-animated_java.project_settings.project_namespace: Project Name
+animated_java.project_settings.project_namespace: Name des Projekts
 animated_java.project_settings.project_namespace.description: |-
-    The name and namespace of the project.
+    Der Name und das Namespace des Projekts.
 animated_java.project_settings.project_namespace.error.unset: |-
-    Project Name cannot be empty
+    Das Projekt muss einen Namen haben.
 
-animated_java.project_settings.project_resolution: Project Resolution
+animated_java.project_settings.project_resolution: Projektauflösung
 animated_java.project_settings.project_resolution.description: |-
-    The UV resolution of the Project.
-    This should equal the resolution of the largest texture in your project.
+    Die UV Auflösung des Projekts.
+    Dies sollte der Auflösung der größten Textur in Ihrem Projekt entsprechen.
 
-animated_java.project_settings.target_minecraft_version: Target Minecraft Version
+animated_java.project_settings.target_minecraft_version: Ziel Minecraft-Version
 animated_java.project_settings.target_minecraft_version.description: |-
-    The version of Minecraft you expect to use the exported rig in.
+    Die Minecraft-Version, in der Sie das exportierte Rig verwenden möchten.
 
 animated_java.project_settings.resourcepack_group: Resource Pack
 
 animated_java.project_settings.rig_item: Rig Item
 animated_java.project_settings.rig_item.description: |-
-    The item to use to display the models used in the rig.
+    Das Element, das für die Anzeige der Modelle auf den Rüstungsständern verwendet wird.
 animated_java.project_settings.rig_item.error.unset: |-
-    Rig Item cannot be empty
+    Rig Item darf nicht leer sein.
 animated_java.project_settings.rig_item.error.space: |-
-    Rig Item must be a valid item ID
-    Item ID cannot contain spaces.
+    Rig Item muss eine gültige Item ID sein.
+    Item IDs dürfen keine Leerzeichen enthalten.
 animated_java.project_settings.rig_item.error.invalid_namespace: |-
-    Rig Item must be a valid item ID
-    Item ID must have a namespace.
+    Rig Item muss eine gültige Item ID sein.
+    Item IDs müssen ein Namespace haben.
 animated_java.project_settings.rig_item.warning.unknown_item: |-
-    Rig Item isn't in vanilla minecraft
-    This may cause issues when exporting.
-    Ignore this warning if you're using snapshots or mods.
+    Rig Item existiert nicht in Vanilla Minecraft.
+    Dies könnte Probleme verursachen beim exportieren.
+    Ignorieren Sie diese Warnung, falls Sie Snapshot-Versionen oder mit Mods spielen.
 
-animated_java.project_settings.enable_advanced_resource_pack_settings: Enable Advanced Resource Pack Settings
+animated_java.project_settings.enable_advanced_resource_pack_settings: Erweiterte Resource Pack Einstellungen aktivieren
 animated_java.project_settings.enable_advanced_resource_pack_settings.description: |-
-    Enable advanced resource pack settings.
-    This will allow you to set the Rig Item Model and Rig Export Folder manually instead of Animated Java automatically figuring it out for you.
-    If you're not sure what this does, leave it disabled.
+    Aktiviert die erweiterten Einstellungen des Resource Packs.
+    Dadurch können Sie manuell das Rig Item-Modell und Exportordner einstellen, anstatt dass Animated Java dies automatisch für Sie erledigt.
+    Wenn Sie sich nicht sicher sind, was dies bewirkt, lassen Sie es deaktiviert.
 
-animated_java.project_settings.rig_item_model: Rig Item Model
+animated_java.project_settings.rig_item_model: Rig Item-Modell
 animated_java.project_settings.rig_item_model.description: |-
-    The export location of the rig item's model.
-    Should be in a valid resource pack under `minecraft:models/item`
+    Der Ordnerpfad des exportierten Rig Item-Modells.
+    Dies sollte in einem gültigen Resource Pack unter `minecraft:models/item` sein.
 animated_java.project_settings.rig_item_model.error.unset: |-
-    Rig Item Model cannot be empty.
+    Rig Item-Modell darf nicht leer sein.
 animated_java.project_settings.rig_item_model.error.invalid_path: |-
-    Rig Item Model must be in a valid resource pack
-    The targeted file must be under 'resources/assets/<namespace>/models/'.
+    Rig Item-Modell muss in einem gültigen Resource Pack sein.
+    Der Zielort muss sich in 'resources/assets/<namespace>/models/' befinden.
 animated_java.project_settings.rig_item_model.error.item_does_not_match: |-
-    Rig Item Model must have the same item name as Rig Item
-    You've selected "%rigItem" as your Rig Item, but Rig Item Model targets "%pathItem".
+    Rig Item-Modell muss den gleichen Namen wie das Rig Item haben.
+    Sie haben das Rig Item als "%rigItem" bestimmt, aber das Rig Item-Modell entspricht "%pathItem".
 animated_java.project_settings.rig_item_model.error.rig_item_unset: |-
-    Rig Item is not set
-    Please set the Rig Item before setting the Rig Item Model.
+    Rig Item ist nicht definiert.
+    Bestimmen Sie zuerst ein Rig Item, bevor Sie das Rig Item-Modell bestimmen.
 
-animated_java.project_settings.rig_export_folder: Rig Export Folder
+animated_java.project_settings.rig_export_folder: Rig Exportordner
 animated_java.project_settings.rig_export_folder.description: |-
-    What folder to put the generated model files in.
-    Should be inside of a valid resource pack.
+    Der Ordner, in den die generierten Modelle gespeichert werden.
+    Dies muss in einem gültigen Resource Pack sein.
 animated_java.project_settings.rig_export_folder.error.unset: |-
-    Rig Export Folder cannot be empty
+    Rig Exportordner darf nicht leer sein.
 animated_java.project_settings.rig_export_folder.error.invalid_path: |-
-    Rig Export Folder must be in a valid resource pack
-    The targeted folder must be under 'resources/assets/<namespace>/models/'.
+    Rig Exportordner muss in einem gültigen Resource Pack sein.
+    Der Zielordner muss sich in 'resources/assets/<namespace>/models/' befinden.
 
-animated_java.project_settings.texture_export_folder: Texture Export Folder
+animated_java.project_settings.texture_export_folder: Textur-Exportordner
 animated_java.project_settings.texture_export_folder.description: |-
-    What folder to put the generated texture files in.
-    Should be inside of a valid resource pack.
+    Der Ordner, in den die generierten Texturen gespeichert werden.
+    Dies muss in einem gültigen Resource Pack sein.
 animated_java.project_settings.texture_export_folder.error.unset: |-
-    Texture Export Folder cannot be empty
+    Textur-Exportordner darf nicht leer sein.
 animated_java.project_settings.texture_export_folder.error.invalid_path: |-
-    Texture Export Folder must be in a valid resource pack
-    The targeted folder must be under 'resources/assets/<namespace>/textures/'.
+    Textur-Exportordner muss in einem gültigen Resource Pack sein.
+    Der Zielordner muss sich in 'resources/assets/<namespace>/textures/' befinden.
 
 animated_java.project_settings.resource_pack_mcmeta: Resource Pack
 animated_java.project_settings.resource_pack_mcmeta.description: |-
-    The Resource Pack to inject the Rig's models into.
-    This setting should be targeting the pack.mcmeta file of a valid Resource Pack.
+    Das Resource Pack, in das die Modelle eingefügt werden.
+    Dieser Dateipfad sollte die 'pack.mcmeta'-Datei eines gültigen Resource Packs bezeichnen.
 animated_java.project_settings.resource_pack_mcmeta.error.unset: |-
-    You must select a Resource Pack.
+    Sie müssen ein Resource Pack auswählen.
 animated_java.project_settings.resource_pack_mcmeta.error.invalid_path: |-
-    The selected path is not a valid Resource Pack!
-    Make sure you've selected the correct pack.mcmeta, and that the Resource Pack has an assets folder.
+    Dieser Pfad ist kein gültiges Resource Pack!
+    Stellen Sie sicher, dass die korrekte 'pack.mcmeta'-Datei ausgewählt wurde und dass das Resource Pack ein 'assets'-Ordner hat.
 
-animated_java.project_settings.verbose: Verbose
+animated_java.project_settings.verbose: Ausführlich
 animated_java.project_settings.verbose.description: |-
-    Whether to print verbose output to the chat when running AJ functions.
-    Useful for debugging.
+    Ob bei der Ausführung von AJ-Funktionen eine ausführliche Nachricht im Chat angezeigt werden.
+    Nützlich für die Fehlersuche und -analyse.
 
 animated_java.project_settings.exporter_settings: '%exporter Settings'
 
 animated_java.project_settings.exporter: Exporter
 animated_java.project_settings.exporter.description: |-
-    The exporter to use when exporting this project.
+    Der Exporter, der beim Exportieren dieses Projekts verwendet werden soll.
 
 ### Bone Config
 animated_java.dialog.bone_config: Animated Java Bone Config

--- a/src/lang/de.yaml
+++ b/src/lang/de.yaml
@@ -1,0 +1,371 @@
+animated_java.title: Animated Java
+
+animated_java.menubar.settings: Animated Java
+
+animated_java.menubar.items.about: About
+animated_java.menubar.items.settings: Settings
+animated_java.menubar.items.project_settings: Project Settings
+animated_java.menubar.items.documentation: Documentation
+animated_java.menubar.items.export_project: Export Project
+animated_java.menubar.items.bone_config: Bone Config
+animated_java.menubar.items.camera_config: Camera Config
+animated_java.menubar.items.locator_config: Locator Config
+
+animated_java.quickmessage.exported_successfully: Project Exported Successfully!
+
+### Dialogs
+animated_java.dialog.close_button: Done
+
+### About
+animated_java.dialog.about.title: About Animated Java
+
+### Export in Progress
+animated_java.dialog.export_in_progress.title: Exporting Project...
+
+### Settings
+animated_java.settings.accessability_options_group: Accessability
+
+animated_java.dialog.settings.title: Animated Java Settings
+animated_java.settings.reduced_motion: Reduced Motion
+animated_java.settings.reduced_motion.description: |-
+    Disable all UI animations in Animated Java's Menus.
+    This will disable animations and other effects that may cause motion sickness.
+
+animated_java.settings.resource_pack_group: Resource Pack
+
+animated_java.settings.minify_output: Minify Output
+animated_java.settings.minify_output.description: |-
+    Minify the output of the exported resource pack.
+    This will remove all comments and whitespace from the output.
+    This will make the output smaller, but will make it harder to read.
+
+### Documentation
+animated_java.dialog.documentation.title: Animated Java Documentation
+
+animated_java.dialog.documentation.loading: Loading Documentation...
+
+animated_java.dialog.documentation.error.failed_to_load.title: Failed to Load Documentation! :(
+animated_java.dialog.documentation.error.failed_to_load.description: |-
+    Make sure you're connected to the internet!
+
+### Project Settings
+animated_java.dialog.project_settings.title: Animated Java Project Settings
+
+animated_java.dialog.project_settings.project_group: Project
+
+animated_java.project_settings.project_namespace: Project Name
+animated_java.project_settings.project_namespace.description: |-
+    The name and namespace of the project.
+animated_java.project_settings.project_namespace.error.unset: |-
+    Project Name cannot be empty
+
+animated_java.project_settings.project_resolution: Project Resolution
+animated_java.project_settings.project_resolution.description: |-
+    The UV resolution of the Project.
+    This should equal the resolution of the largest texture in your project.
+
+animated_java.project_settings.target_minecraft_version: Target Minecraft Version
+animated_java.project_settings.target_minecraft_version.description: |-
+    The version of Minecraft you expect to use the exported rig in.
+
+animated_java.project_settings.resourcepack_group: Resource Pack
+
+animated_java.project_settings.rig_item: Rig Item
+animated_java.project_settings.rig_item.description: |-
+    The item to use to display the models used in the rig.
+animated_java.project_settings.rig_item.error.unset: |-
+    Rig Item cannot be empty
+animated_java.project_settings.rig_item.error.space: |-
+    Rig Item must be a valid item ID
+    Item ID cannot contain spaces.
+animated_java.project_settings.rig_item.error.invalid_namespace: |-
+    Rig Item must be a valid item ID
+    Item ID must have a namespace.
+animated_java.project_settings.rig_item.warning.unknown_item: |-
+    Rig Item isn't in vanilla minecraft
+    This may cause issues when exporting.
+    Ignore this warning if you're using snapshots or mods.
+
+animated_java.project_settings.enable_advanced_resource_pack_settings: Enable Advanced Resource Pack Settings
+animated_java.project_settings.enable_advanced_resource_pack_settings.description: |-
+    Enable advanced resource pack settings.
+    This will allow you to set the Rig Item Model and Rig Export Folder manually instead of Animated Java automatically figuring it out for you.
+    If you're not sure what this does, leave it disabled.
+
+animated_java.project_settings.rig_item_model: Rig Item Model
+animated_java.project_settings.rig_item_model.description: |-
+    The export location of the rig item's model.
+    Should be in a valid resource pack under `minecraft:models/item`
+animated_java.project_settings.rig_item_model.error.unset: |-
+    Rig Item Model cannot be empty.
+animated_java.project_settings.rig_item_model.error.invalid_path: |-
+    Rig Item Model must be in a valid resource pack
+    The targeted file must be under 'resources/assets/<namespace>/models/'.
+animated_java.project_settings.rig_item_model.error.item_does_not_match: |-
+    Rig Item Model must have the same item name as Rig Item
+    You've selected "%rigItem" as your Rig Item, but Rig Item Model targets "%pathItem".
+animated_java.project_settings.rig_item_model.error.rig_item_unset: |-
+    Rig Item is not set
+    Please set the Rig Item before setting the Rig Item Model.
+
+animated_java.project_settings.rig_export_folder: Rig Export Folder
+animated_java.project_settings.rig_export_folder.description: |-
+    What folder to put the generated model files in.
+    Should be inside of a valid resource pack.
+animated_java.project_settings.rig_export_folder.error.unset: |-
+    Rig Export Folder cannot be empty
+animated_java.project_settings.rig_export_folder.error.invalid_path: |-
+    Rig Export Folder must be in a valid resource pack
+    The targeted folder must be under 'resources/assets/<namespace>/models/'.
+
+animated_java.project_settings.texture_export_folder: Texture Export Folder
+animated_java.project_settings.texture_export_folder.description: |-
+    What folder to put the generated texture files in.
+    Should be inside of a valid resource pack.
+animated_java.project_settings.texture_export_folder.error.unset: |-
+    Texture Export Folder cannot be empty
+animated_java.project_settings.texture_export_folder.error.invalid_path: |-
+    Texture Export Folder must be in a valid resource pack
+    The targeted folder must be under 'resources/assets/<namespace>/textures/'.
+
+animated_java.project_settings.resource_pack_mcmeta: Resource Pack
+animated_java.project_settings.resource_pack_mcmeta.description: |-
+    The Resource Pack to inject the Rig's models into.
+    This setting should be targeting the pack.mcmeta file of a valid Resource Pack.
+animated_java.project_settings.resource_pack_mcmeta.error.unset: |-
+    You must select a Resource Pack.
+animated_java.project_settings.resource_pack_mcmeta.error.invalid_path: |-
+    The selected path is not a valid Resource Pack!
+    Make sure you've selected the correct pack.mcmeta, and that the Resource Pack has an assets folder.
+
+animated_java.project_settings.verbose: Verbose
+animated_java.project_settings.verbose.description: |-
+    Whether to print verbose output to the chat when running AJ functions.
+    Useful for debugging.
+
+animated_java.project_settings.exporter_settings: '%exporter Settings'
+
+animated_java.project_settings.exporter: Exporter
+animated_java.project_settings.exporter.description: |-
+    The exporter to use when exporting this project.
+
+### Bone Config
+animated_java.dialog.bone_config: Animated Java Bone Config
+animated_java.bone_config.nbt: Bone Entity NBT
+animated_java.bone_config.nbt.description: |-
+    Custom NBT to apply to this bone entity.
+    Note that some internal NBT may take priority over this setting.
+
+### Camera Config
+animated_java.dialog.camera_config: Animated Java Camera Config
+
+animated_java.camera_config.entity_type: Teleported Entity Type
+animated_java.camera_config.entity_type.description: |-
+    The entity to use when summoning the camera.
+    For instance, if you set this to `minecraft:armor_stand`, The camera will be a armor_stand in-game.
+animated_java.camera_config.entity_type.error.space: |-
+    Entity IDs cannot contain spaces.
+animated_java.camera_config.entity_type.error.invalid_namespace: |-
+    Entity IDs must have a namespace.
+animated_java.camera_config.entity_type.warning.unknown_entity: |-
+    Entity ID isn't in vanilla minecraft
+    This may cause issues when exporting.
+    Ignore this warning if you're using snapshots or mods.
+
+animated_java.camera_config.nbt: NBT
+animated_java.camera_config.nbt.description: |-
+    Custom NBT to apply to the summoned camera entity.
+    Note that some internal NBT tags will take priority over this setting.
+
+### Locator Config
+animated_java.dialog.locator_config: Animated Java Locator Config
+
+animated_java.locator_config.entity_type: Entity Type
+animated_java.locator_config.entity_type.description: |-
+    The entity to use when summoning the locator.
+    For instance, if you set this to `minecraft:pig`, The locator will be a pig in-game.
+animated_java.locator_config.entity_type.error.space: |-
+    Entity IDs cannot contain spaces.
+animated_java.locator_config.entity_type.error.invalid_namespace: |-
+    Entity IDs must have a namespace.
+animated_java.locator_config.entity_type.warning.unknown_entity: |-
+    Entity ID isn't in vanilla minecraft
+    This may cause issues when exporting.
+    Ignore this warning if you're using snapshots or mods.
+
+animated_java.locator_config.nbt: NBT
+animated_java.locator_config.nbt.description: |-
+    Custom NBT to apply to the summoned locator entity.
+    Note that some internal NBT tags will take priority over this setting.
+
+### Animation Config
+animated_java.dialog.animation_config.title: Animation Properties
+
+animated_java.animation_config.animation_name: Name
+animated_java.animation_config.animation_name.description: |-
+    The name of the animation.
+animated_java.animation_config.animation_name.error.duplicate_name: |-
+    An animation with the name "%name" already exists.
+    Animation names must be unique.
+
+animated_java.animation_config.loop: Loop Mode
+animated_java.animation_config.loop.description: |-
+    The loop mode of the animation.
+    once: The animation will only play once and immediately reset once complete.
+    loop: The animation will loop forever.
+    hold: The animation will hold on the last frame.
+animated_java.animation_config.loop.options.once: Play Once
+animated_java.animation_config.loop.options.loop: Loop
+animated_java.animation_config.loop.options.hold: Hold on Last Frame
+
+animated_java.animation_config.loop_delay: Loop Delay
+animated_java.animation_config.loop_delay.description: |-
+    The delay (in ticks) between loops of the animation.
+    Only applies if the loop mode is set to loop.
+
+animated_java.animation_config.start_delay: Start Delay
+animated_java.animation_config.start_delay.description: |-
+    The delay (in ticks) before the animation starts after the play function is ran.
+
+animated_java.animation_config.affected_bones_is_a_whitelist: Ignored Bones is a Whitelist
+animated_java.animation_config.affected_bones_is_a_whitelist.description: |-
+    If true, only the bones in the Ignored Bones list will be affected by this animation.
+    If false, all bones except the ones in the Ignored Bones list will be affected by this animation.
+
+animated_java.animation_config.affected_bones: Ignored Bones
+animated_java.animation_config.affected_bones.add_new_item_message: Add a Bone
+animated_java.animation_config.affected_bones.description: |-
+    The bones that this animation will affect.
+    If this list is a whitelist, only the bones in the Ignored Bones list will be affected by this animation.
+    If this list is a blacklist, all bones except the ones in the Ignored Bones list will be affected by this animation.
+
+### Variants Panel
+animated_java.panels.variants.name: Variants
+animated_java.panels.variants.items: Variant
+animated_java.panels.variants.delete_default_variant: Cannot delete default Variant
+animated_java.panels.variants.delete_variant: Delete Variant
+animated_java.panels.variants.edit_variant: Edit Variant
+animated_java.panels.variants.default_variant: Default Variant
+animated_java.actions.add_variant.name: Add Variant
+animated_java.actions.add_variant.description: Create a new Variant
+animated_java.actions.variant_properties.name: Variant Properties
+animated_java.actions.variant_properties.description: Open the Variant properties dialog.
+animated_java.actions.duplicate_variant.name: Duplicate Variant
+animated_java.actions.duplicate_variant.description: Duplicate this Variant.
+
+### Variants Properties Dialog
+animated_java.dialog.variant_properties.title: Variant Properties
+
+animated_java.dialog.variant_properties.variant_name: Name
+animated_java.dialog.variant_properties.variant_name.description: |-
+    The name of the variant.
+animated_java.variant_properties.variant_name.error.duplicate_name: |-
+    A variant with the name "%name" already exists.
+    Variant names must be unique.
+
+animated_java.dialog.variant_properties.affected_bones_is_a_whitelist: Affected Bones is a Whitelist
+animated_java.dialog.variant_properties.affected_bones_is_a_whitelist.description: |-
+    Whether the affected bones list is a whitelist or blacklist.
+    If true, only the bones in the Affected Bones list will be affected by this Variant.
+    If false, all bones except the ones in the Affected Bones list will be affected by this Variant.
+
+animated_java.dialog.variant_properties.affected_bones: Affected Bones
+animated_java.dialog.variant_properties.affected_bones.add_new_item_message: Add a Bone
+animated_java.dialog.variant_properties.affected_bones.description: |-
+    The list of bones affected by this variant.
+    If this is a whitelist, only the bones in the list will be modified by this Variant.
+    If this is a blacklist, all bones except the ones in the list will be modified by this Variant.
+animated_java.dialog.variant_properties.textureMap: Texture Map
+animated_java.dialog.variant_properties.textureMap.description: |-
+    The texture map to use for this variant.
+    Lets you choose what textures are replaced when this Variant is appied.
+
+### Custom Keyframes
+animated_java.keyframe.animation: Animation
+animated_java.keyframe.animation.description: |-
+    The animation to apply when this keyframe is reached.
+
+animated_java.keyframe.variant: Variant
+animated_java.keyframe.variant.description: |-
+    The variant to apply when this keyframe is reached.
+
+animated_java.keyframe.commands: Commands
+animated_java.keyframe.commands.description: |-
+    A list of commands (A function) that run when the keyframe is reached.
+
+animated_java.keyframe.tweenDuration: Tween Duration
+animated_java.keyframe.tweenDuration.description: |-
+    The duration (in ticks) of the tween between this keyframe and the next animation.
+
+animated_java.keyframe.tweenMode: Tween Mode
+animated_java.keyframe.tweenMode.description: |-
+    The tween mode of the keyframe.
+    Play: The animation will play from the start.
+    Resume: The animation will play from the same anim_time as this keyframe.
+animated_java.keyframe.tweenMode.play: Play
+animated_java.keyframe.tweenMode.resume: Resume
+
+animated_java.keyframe.executeCondition: Execute Condition
+animated_java.keyframe.executeCondition.description: |-
+    The execute command condition that must be met for the keyframe to be applied.
+    This is an execute subcommand chain, so you can use any and all execute subcommands in this field.
+    Example: "if score @s example matches 1.."
+    Hint: You can separate subcommands with newlines!
+
+animated_java.keyframe.playsound: Sound
+animated_java.keyframe.playsound.description: |-
+    The sound that is executed using the playsound command at this keyframe.
+
+animated_java.timeline.animation: Animations
+animated_java.timeline.variant: Variants
+animated_java.timeline.commands: Commands
+animated_java.timeline.playsound: Playsound
+
+### Popups
+animated_java.popup.close_button: Close
+animated_java.popup.confirm_button: Done
+animated_java.popup.cancel_button: Done
+
+# Unexpected Error
+animated_java.popup.unexpectedError.title: Unexpected Error
+animated_java.popup.unexpectedError.body: |-
+    An unexpected error occurred!
+    Please report this error on our Github or in the support channel on our official Discord server.
+
+# Confirm predicate file overwrite
+animated_java.popup.confirm_predicate_file_overwrite.title: Confirm Predicate File Overwrite
+animated_java.popup.confirm_predicate_file_overwrite.body: |-
+    The file "%file" already exists and is not a Rig Item Model!
+    Do you want to overwrite it?
+
+    Full file path:
+    %path
+
+# Invalid Texture Mapping(s)
+animated_java.popup.invalid_texture_mapping.title: Invalid Texture Mapping(s)
+animated_java.popup.invalid_texture_mapping.body: |-
+    The Variant "%variant" has invalid texture mappings!
+    One or more of the textures in it's texture map are missing from the project, or are invalid.
+    The invalid mappings and a brief explanation of why they're invalid can be found below:
+animated_java.popup.invalid_texture_mapping.reason: Reason(s) for Invalidation
+animated_java.popup.invalid_texture_mapping.reason.invalid_from_texture: |-
+    Couldn't find the "from" texture in the project.
+animated_java.popup.invalid_texture_mapping.reason.invalid_to_texture: |-
+    Couldn't find the "to" texture in the project.
+animated_java.popup.invalid_texture_mapping.footer: |-
+    The missing/invalid texture mappings will be removed from the variant.
+    After closing this popup, please make sure you open the Variant's properties dialog and double check the texture mappings are correct.
+
+# Invalid Cube(s)
+animated_java.popup.invalid_cubes.title: Invalid Cube(s)
+animated_java.popup.invalid_cubes.body: |-
+    Some Cubes have invalid rotations!
+    The invalid cubes can be found below sorted by the Bones they're in.
+    They will also be highlighted in the 3D view once you exit this dialog.
+
+# Failed Project Export Readiness
+animated_java.popup.failed_project_export_readiness.title: Export Failed
+animated_java.popup.failed_project_export_readiness.body: |-
+    The project is not ready to be exported!
+    The following issues were found:
+animated_java.popup.failed_project_export_readiness.issue: Project Setting "%s" has the following errors

--- a/src/lang/de.yaml
+++ b/src/lang/de.yaml
@@ -240,45 +240,44 @@ animated_java.animation_config.affected_bones.description: |-
     Falls diese Liste eine Black-Liste ist, werden alle Knochen außer denen in der Liste von dieser Animation betroffen sein.
 
 ### Variants Panel
-animated_java.panels.variants.name: Variants
-animated_java.panels.variants.items: Variant
-animated_java.panels.variants.delete_default_variant: Cannot delete default Variant
-animated_java.panels.variants.delete_variant: Delete Variant
-animated_java.panels.variants.edit_variant: Edit Variant
-animated_java.panels.variants.default_variant: Default Variant
-animated_java.actions.add_variant.name: Add Variant
-animated_java.actions.add_variant.description: Create a new Variant
-animated_java.actions.variant_properties.name: Variant Properties
-animated_java.actions.variant_properties.description: Open the Variant properties dialog.
-animated_java.actions.duplicate_variant.name: Duplicate Variant
-animated_java.actions.duplicate_variant.description: Duplicate this Variant.
+animated_java.panels.variants.name: Varianten
+animated_java.panels.variants.items: Variante
+animated_java.panels.variants.delete_default_variant: Standard-Varianten können nicht gelöscht werden.
+animated_java.panels.variants.delete_variant: Variante löschen
+animated_java.panels.variants.edit_variant: Variante bearbeiten
+animated_java.panels.variants.default_variant: Standard-Variante
+animated_java.actions.add_variant.name: Variante hinzufügen
+animated_java.actions.add_variant.description: Neue Variante erstellen
+animated_java.actions.variant_properties.name: Varianten-Eigenschaften
+animated_java.actions.variant_properties.description: Öffnet den Dialog für Varianten-Eigenschaften.
+animated_java.actions.duplicate_variant.name: Variante duplizieren
+animated_java.actions.duplicate_variant.description: Dupliziert diese Variante.
 
 ### Variants Properties Dialog
-animated_java.dialog.variant_properties.title: Variant Properties
+animated_java.dialog.variant_properties.title: Varianten-Eigenschaften
 
 animated_java.dialog.variant_properties.variant_name: Name
 animated_java.dialog.variant_properties.variant_name.description: |-
-    The name of the variant.
+    Der Name der Variante.
 animated_java.variant_properties.variant_name.error.duplicate_name: |-
-    A variant with the name "%name" already exists.
-    Variant names must be unique.
+    Eine Variante mit dem Namen "%name" existiert bereits.
+    Namen müssen eindeutig sein.
 
-animated_java.dialog.variant_properties.affected_bones_is_a_whitelist: Affected Bones is a Whitelist
+animated_java.dialog.variant_properties.affected_bones_is_a_whitelist: Ignorierte Knochen sind eine White-Liste
 animated_java.dialog.variant_properties.affected_bones_is_a_whitelist.description: |-
-    Whether the affected bones list is a whitelist or blacklist.
-    If true, only the bones in the Affected Bones list will be affected by this Variant.
-    If false, all bones except the ones in the Affected Bones list will be affected by this Variant.
+    Falls wahr, werden nur Knochen auf der 'Ignorierte Knochen'-Liste von dieser Variante betroffen sein.
+    Falls falsch, werden alle Knochen außer denen in der Liste von dieser Variente betroffen sein.
 
-animated_java.dialog.variant_properties.affected_bones: Affected Bones
-animated_java.dialog.variant_properties.affected_bones.add_new_item_message: Add a Bone
+animated_java.dialog.variant_properties.affected_bones: Ignorierte Knochen
+animated_java.dialog.variant_properties.affected_bones.add_new_item_message: Knochen hinzufügen
 animated_java.dialog.variant_properties.affected_bones.description: |-
-    The list of bones affected by this variant.
-    If this is a whitelist, only the bones in the list will be modified by this Variant.
-    If this is a blacklist, all bones except the ones in the list will be modified by this Variant.
-animated_java.dialog.variant_properties.textureMap: Texture Map
+    Die Knochen, die diese Variante beeinflussen wird.
+    Falls diese Liste eine White-Liste ist, werden nur aufgeführte Knochen von dieser Variante betroffen sein.
+    Falls diese Liste eine Black-Liste ist, werden alle Knochen außer denen in der Liste von dieser Variante betroffen sein.
+animated_java.dialog.variant_properties.textureMap: Textur-Map
 animated_java.dialog.variant_properties.textureMap.description: |-
-    The texture map to use for this variant.
-    Lets you choose what textures are replaced when this Variant is appied.
+    Die Textur-Map, die für diese Variante verwendet wird.
+    Hier können Sie auswählen, welche Texturen bei der Anwendung dieser Variante ersetzt werden.
 
 ### Custom Keyframes
 animated_java.keyframe.animation: Animation

--- a/src/lang/de.yaml
+++ b/src/lang/de.yaml
@@ -282,89 +282,84 @@ animated_java.dialog.variant_properties.textureMap.description: |-
 ### Custom Keyframes
 animated_java.keyframe.animation: Animation
 animated_java.keyframe.animation.description: |-
-    The animation to apply when this keyframe is reached.
+    Die Animation, die angewendet wird, sobald dieser Keyframe erreicht wird.
 
-animated_java.keyframe.variant: Variant
+animated_java.keyframe.variant: Variante
 animated_java.keyframe.variant.description: |-
-    The variant to apply when this keyframe is reached.
+    Die Variante, die angewendet wird, sobald dieser Keyframe erreicht wird.
 
-animated_java.keyframe.commands: Commands
+animated_java.keyframe.commands: Befehle
 animated_java.keyframe.commands.description: |-
-    A list of commands (A function) that run when the keyframe is reached.
+    Eine Liste von Befehlen (eine Funktion), die ausgeführt wird, sobald dieser Keyframe erreicht wird.
 
-animated_java.keyframe.tweenDuration: Tween Duration
+animated_java.keyframe.tweenDuration: Tween-Dauer
 animated_java.keyframe.tweenDuration.description: |-
-    The duration (in ticks) of the tween between this keyframe and the next animation.
+    Die Dauer des Tweens (in Ticks) zwischen diesem Keyframe und der nächsten Animation.
 
-animated_java.keyframe.tweenMode: Tween Mode
+animated_java.keyframe.tweenMode: Tween-Modus
 animated_java.keyframe.tweenMode.description: |-
-    The tween mode of the keyframe.
-    Play: The animation will play from the start.
-    Resume: The animation will play from the same anim_time as this keyframe.
-animated_java.keyframe.tweenMode.play: Play
-animated_java.keyframe.tweenMode.resume: Resume
+    Der Tween-Modus dieses Keyframes.
+    Abspielen: Die Animation wird von Anfang an abgespielt.
+    Fortsetzen: Die Animation wird von derselben anim_time wie dieser Keyframe abgespielt.
+animated_java.keyframe.tweenMode.play: Abspielen
+animated_java.keyframe.tweenMode.resume: Fortsetzen
 
-animated_java.keyframe.executeCondition: Execute Condition
+animated_java.keyframe.executeCondition: Ausführungsbedingung
 animated_java.keyframe.executeCondition.description: |-
-    The execute command condition that must be met for the keyframe to be applied.
-    This is an execute subcommand chain, so you can use any and all execute subcommands in this field.
-    Example: "if score @s example matches 1.."
-    Hint: You can separate subcommands with newlines!
+    Die Ausführungsbedingung, die erfüllt sein muss, damit der Keyframe angewendet wird.
+    Dies ist eine Kette von 'execute'-Unterbefehlen, also können Sie alle Unterbefehle in diesem Feld benutzen.
+    Beispiel: "if score @s example matches 1.."
+    Tipp: Sie können Unterbefehle mit Zeilenumbrüchen trennen!
 
-animated_java.keyframe.playsound: Sound
-animated_java.keyframe.playsound.description: |-
-    The sound that is executed using the playsound command at this keyframe.
-
-animated_java.timeline.animation: Animations
-animated_java.timeline.variant: Variants
-animated_java.timeline.commands: Commands
-animated_java.timeline.playsound: Playsound
+animated_java.timeline.animation: Animationen
+animated_java.timeline.variant: Varianten
+animated_java.timeline.commands: Befehle
 
 ### Popups
-animated_java.popup.close_button: Close
-animated_java.popup.confirm_button: Done
-animated_java.popup.cancel_button: Done
+animated_java.popup.close_button: Schließen
+animated_java.popup.confirm_button: Fertig
+animated_java.popup.cancel_button: Abbrechen
 
 # Unexpected Error
-animated_java.popup.unexpectedError.title: Unexpected Error
+animated_java.popup.unexpectedError.title: Unerwarteter Fehler
 animated_java.popup.unexpectedError.body: |-
-    An unexpected error occurred!
-    Please report this error on our Github or in the support channel on our official Discord server.
+    Ein unerwarteter Fehler ist aufgetreten!
+    Bitte melden Sie diesen Fehler auf unserem Github oder im Support-Kanal unseres offizielem Discord-Servers.
 
 # Confirm predicate file overwrite
-animated_java.popup.confirm_predicate_file_overwrite.title: Confirm Predicate File Overwrite
+animated_java.popup.confirm_predicate_file_overwrite.title: Bestätigen Sie die Überschreibung der Predicate-Datei
 animated_java.popup.confirm_predicate_file_overwrite.body: |-
-    The file "%file" already exists and is not a Rig Item Model!
-    Do you want to overwrite it?
+    Die Datei "%file" existiert bereits und ist nicht ein Rig Item-Modell!
+    Möchten Sie es überschreiben?
 
-    Full file path:
+    Dateipfad:
     %path
 
 # Invalid Texture Mapping(s)
-animated_java.popup.invalid_texture_mapping.title: Invalid Texture Mapping(s)
+animated_java.popup.invalid_texture_mapping.title: Ungültige Textur-Zuordnung(en)
 animated_java.popup.invalid_texture_mapping.body: |-
-    The Variant "%variant" has invalid texture mappings!
-    One or more of the textures in it's texture map are missing from the project, or are invalid.
-    The invalid mappings and a brief explanation of why they're invalid can be found below:
-animated_java.popup.invalid_texture_mapping.reason: Reason(s) for Invalidation
+    Die Variante "%variant" hat ungültige Textur-Zuordnungen!
+    Eine oder mehrere Texturen in der Textur-Map fehlen im Projekt oder sind ungültig.
+    Die ungültigen Zuordnungen und eine kurze Erkärung, warum sie ungültig sind, finden Sie unten:
+animated_java.popup.invalid_texture_mapping.reason: Ungültigkeitsgründe
 animated_java.popup.invalid_texture_mapping.reason.invalid_from_texture: |-
-    Couldn't find the "from" texture in the project.
+    Die 'von' Textur konnte im Projekt nicht gefunden werden.
 animated_java.popup.invalid_texture_mapping.reason.invalid_to_texture: |-
-    Couldn't find the "to" texture in the project.
+    Die 'zu' Textur konnte im Projekt nicht gefunden werden.
 animated_java.popup.invalid_texture_mapping.footer: |-
-    The missing/invalid texture mappings will be removed from the variant.
-    After closing this popup, please make sure you open the Variant's properties dialog and double check the texture mappings are correct.
+    Die fehlenden / ungültigen Textur-Zuordnungen werden von der Variante entfernt.
+    Nachdem Sie das Popup geschlossen haben, überprüfen Sie bitte, ob die Textur-Zuordnungen in den Varianten-Eigenschaften korrekt sind.
 
 # Invalid Cube(s)
-animated_java.popup.invalid_cubes.title: Invalid Cube(s)
+animated_java.popup.invalid_cubes.title: Ungültige Form(en)
 animated_java.popup.invalid_cubes.body: |-
-    Some Cubes have invalid rotations!
-    The invalid cubes can be found below sorted by the Bones they're in.
-    They will also be highlighted in the 3D view once you exit this dialog.
+    Einige Formen haben ungültige Drehungen!
+    Die ungültigen Formen können Sie unten finden, sortiert nach den Knochen, in denen sie sich befinden.
+    Die Formen werden auch in der 3D-Ansicht hervorgehoben, sobald Sie dieses Popup schliessen.
 
 # Failed Project Export Readiness
-animated_java.popup.failed_project_export_readiness.title: Export Failed
+animated_java.popup.failed_project_export_readiness.title: Export fehlgeschlagen
 animated_java.popup.failed_project_export_readiness.body: |-
-    The project is not ready to be exported!
-    The following issues were found:
-animated_java.popup.failed_project_export_readiness.issue: Project Setting "%s" has the following errors
+    Dieses Projekt ist nicht bereit, exportiert zu werden!
+    Die folgenden Probleme wurden festgestellt:
+animated_java.popup.failed_project_export_readiness.issue: Projekteinstellung "%s" hat den folgenden Fehler

--- a/src/lang/de.yaml
+++ b/src/lang/de.yaml
@@ -150,32 +150,32 @@ animated_java.project_settings.exporter.description: |-
     Der Exporter, der beim Exportieren dieses Projekts verwendet werden soll.
 
 ### Bone Config
-animated_java.dialog.bone_config: Animated Java Bone Config
-animated_java.bone_config.nbt: Bone Entity NBT
+animated_java.dialog.bone_config: Animated Java Knochen-Konfiguration
+animated_java.bone_config.nbt: Knochen NBT
 animated_java.bone_config.nbt.description: |-
-    Custom NBT to apply to this bone entity.
-    Note that some internal NBT may take priority over this setting.
+    Benutzerdefinierte NBT, die bei diesem Knochen angewendet werden soll.
+    Beachten Sie, dass einige interne NBT Vorrang vor dieser Einstellung habn können.
 
 ### Camera Config
-animated_java.dialog.camera_config: Animated Java Camera Config
+animated_java.dialog.camera_config: Animated Java Kamera-Konfiguration
 
-animated_java.camera_config.entity_type: Teleported Entity Type
+animated_java.camera_config.entity_type: Typ des teleportierten Objektes
 animated_java.camera_config.entity_type.description: |-
-    The entity to use when summoning the camera.
-    For instance, if you set this to `minecraft:armor_stand`, The camera will be a armor_stand in-game.
+    Das Objekt, das beim Erzeugen der Kamera verwendet werden soll.
+    Zum Beispiel, falls Sie `minecraft:armor_stand` einstellen, wird die Kamera im Spiel zu einem armor_stand.
 animated_java.camera_config.entity_type.error.space: |-
-    Entity IDs cannot contain spaces.
+    Objekt-IDs dürfen keine Leerzeichen enthalten.
 animated_java.camera_config.entity_type.error.invalid_namespace: |-
-    Entity IDs must have a namespace.
+    Objekt-IDs müssen ein Namespace haben.
 animated_java.camera_config.entity_type.warning.unknown_entity: |-
-    Entity ID isn't in vanilla minecraft
-    This may cause issues when exporting.
-    Ignore this warning if you're using snapshots or mods.
+    Objekt existiert nicht in Vanilla Minecraft.
+    Dies könnte Probleme verursachen beim exportieren.
+    Ignorieren Sie diese Warnung, falls Sie Snapshot-Versionen oder mit Mods spielen.
 
 animated_java.camera_config.nbt: NBT
 animated_java.camera_config.nbt.description: |-
-    Custom NBT to apply to the summoned camera entity.
-    Note that some internal NBT tags will take priority over this setting.
+    Benutzerdefinierte NBT, die bei dieser Kamera angewendet werden soll.
+    Beachten Sie, dass einige interne NBT Vorrang vor dieser Einstellung habn können.
 
 ### Locator Config
 animated_java.dialog.locator_config: Animated Java Locator Config

--- a/src/lang/de.yaml
+++ b/src/lang/de.yaml
@@ -199,45 +199,45 @@ animated_java.locator_config.nbt.description: |-
     Beachten Sie, dass einige interne NBT Vorrang vor dieser Einstellung habn können.
 
 ### Animation Config
-animated_java.dialog.animation_config.title: Animation Properties
+animated_java.dialog.animation_config.title: Animationseigenschaften
 
 animated_java.animation_config.animation_name: Name
 animated_java.animation_config.animation_name.description: |-
-    The name of the animation.
+    Der Name der Animation.
 animated_java.animation_config.animation_name.error.duplicate_name: |-
-    An animation with the name "%name" already exists.
-    Animation names must be unique.
+    Es existiert bereits eine Animation namens "%name".
+    Animationsnamen müssen eindeutig sein.
 
-animated_java.animation_config.loop: Loop Mode
+animated_java.animation_config.loop: Wiederholungsmodus
 animated_java.animation_config.loop.description: |-
-    The loop mode of the animation.
-    once: The animation will only play once and immediately reset once complete.
-    loop: The animation will loop forever.
-    hold: The animation will hold on the last frame.
-animated_java.animation_config.loop.options.once: Play Once
-animated_java.animation_config.loop.options.loop: Loop
-animated_java.animation_config.loop.options.hold: Hold on Last Frame
+    Der Wiederholungsmodus der Animation.
+    Einmal: Die Animation wird nur einmal abspielen und danach sofort zurückgesetzt.
+    Wiederholen: Die Animation wird sich unendlich wiederholen.
+    Halten: Die Animation wird beim letzten letzten Bild angehalten.
+animated_java.animation_config.loop.options.once: Einmal abspielen
+animated_java.animation_config.loop.options.loop: Wiederholen
+animated_java.animation_config.loop.options.hold: Auf letztem Bild halten
 
-animated_java.animation_config.loop_delay: Loop Delay
+animated_java.animation_config.loop_delay: Wiederholungsverzögerung
 animated_java.animation_config.loop_delay.description: |-
-    The delay (in ticks) between loops of the animation.
-    Only applies if the loop mode is set to loop.
+    Die Verzögerung (in Ticks) zwischen Wiederholungen der Animation.
+    Gilt nur, wenn der Wiederholungsmodus auf 'Wiederholen' eingestellt ist.
 
-animated_java.animation_config.start_delay: Start Delay
+animated_java.animation_config.start_delay: Startverzögerung
 animated_java.animation_config.start_delay.description: |-
-    The delay (in ticks) before the animation starts after the play function is ran.
+    Die Verzögerung (in Ticks) zwischen der Ausführung der Funktion und dem Abspielen der Animation.
 
-animated_java.animation_config.affected_bones_is_a_whitelist: Ignored Bones is a Whitelist
+animated_java.animation_config.affected_bones_is_a_whitelist: Ignorierte Knochen sind eine White-Liste
 animated_java.animation_config.affected_bones_is_a_whitelist.description: |-
-    If true, only the bones in the Ignored Bones list will be affected by this animation.
-    If false, all bones except the ones in the Ignored Bones list will be affected by this animation.
+    Falls wahr, werden nur Knochen auf der 'Ignorierte Knochen'-Liste von dieser Animation betroffen sein.
+    Falls falsch, werden alle Knochen außer denen in der Liste von dieser Animation betroffen sein.
 
-animated_java.animation_config.affected_bones: Ignored Bones
-animated_java.animation_config.affected_bones.add_new_item_message: Add a Bone
+animated_java.animation_config.affected_bones: Ignorierte Knochen
+animated_java.animation_config.affected_bones.add_new_item_message: Knochen hinzufügen
 animated_java.animation_config.affected_bones.description: |-
-    The bones that this animation will affect.
-    If this list is a whitelist, only the bones in the Ignored Bones list will be affected by this animation.
-    If this list is a blacklist, all bones except the ones in the Ignored Bones list will be affected by this animation.
+    Die Knochen, die diese Animation beeinflussen wird.
+    Falls diese Liste eine White-Liste ist, werden nur aufgeführte Knochen von dieser Animation betroffen sein.
+    Falls diese Liste eine Black-Liste ist, werden alle Knochen außer denen in der Liste von dieser Animation betroffen sein.
 
 ### Variants Panel
 animated_java.panels.variants.name: Variants

--- a/src/util/translation.ts
+++ b/src/util/translation.ts
@@ -1,9 +1,15 @@
 // @ts-ignore
 import en from '../lang/en.yaml'
+// @ts-ignore
+import de from '../lang/de.yaml'
+// @ts-ignore
+import zh from '../lang/zh_cn.yaml'
 import { formatStr, FormattingObject } from './misc'
 
 const LANGUAGES: Record<string, Record<string, string>> = {
 	en,
+	de,
+	zh,
 }
 
 export const currentLanguage = settings.language.value


### PR DESCRIPTION
Converted the current **en.yaml** file to a german version **de.yaml**.
May have minor misspelled words of **ss -> ß**. It does not hurt readability, but if someone from Germany wishes to proof-read this, that will be the most likely mistake.