### PR TITLE
Fix icon name so it shows up appropriately

### DIFF
--- a/src/ui/ajMenuBar.ts
+++ b/src/ui/ajMenuBar.ts
@@ -48,7 +48,7 @@ events.UNSELECT_PROJECT.subscribe(() => {
 
 MenuBar.addAction(
 	createAction('animated_java:about', {
-		icon: 'info_outline',
+		icon: 'info',
 		category: 'animated_java',
 		name: translate('animated_java.menubar.items.about'),
 		condition: () => Format === ajModelFormat,


### PR DESCRIPTION
The icon name is incorrect, which causes this for some reason:
![image](https://github.com/Animated-Java/animated-java/assets/647786/58cb4826-2c6a-4a5a-9831-60cb2609d183)

Changing it fixes it:
![image](https://github.com/Animated-Java/animated-java/assets/647786/428919cc-458b-41f3-bb3d-4ed04854b7ad)
