### PR TITLE
🐛 Fix "Skipping entity with id" Minecraft log spam

### DIFF
--- a/src/systems/datapackCompiler.ts
+++ b/src/systems/datapackCompiler.ts
@@ -380,6 +380,9 @@ async function generateRootEntityPassengers(rig: IRenderedRig, rigHash: string) 
 				}
 				break
 			}
+			default: {
+				continue
+			}
 		}
 
 		passengers.add(passenger)


### PR DESCRIPTION
anytime you summon an entity with locators (or other non-bone/display types), the game logged a warning: "Skipping entity with id". this warning spams the log very quickly when many AJ models are summoned in-game

the switch block that generates the root entity's passengers was adding a passenger entity for each node in the rig. not all nodes are actually a passenger of the root entity though.

these nodes were still being added to the passenger list with only a `Tags:["aj.rig_entity"]` field. Minecraft sees this entity and skips it because it has no specified `id`

(the warning in-game should say "Skipping entity with**out** id" instead)

---

| before | after |
|-|-|
|![image](https://github.com/user-attachments/assets/99e86422-cb91-4b64-b695-26aec8309cd5)|![image](https://github.com/user-attachments/assets/decb3ccd-9fcf-4acd-99b0-f4f75aba3f63)|