### PR TITLE
Allow namespaces to create subfolders

### DIFF
--- a/src/blueprintFormat.ts
+++ b/src/blueprintFormat.ts
@@ -4,7 +4,7 @@ import ProjectTitleSvelte from './components/projectTitle.svelte'
 import { PACKAGE } from './constants'
 import { events } from './util/events'
 import { injectSvelteCompomponent } from './util/injectSvelteComponent'
-import { toSafeFuntionName } from './util/minecraftUtil'
+import { toSafeFunctionName } from './util/minecraftUtil'
 import { addProjectToRecentProjects } from './util/misc'
 import { Valuable } from './util/stores'
 import { TRANSPARENT_TEXTURE, TRANSPARENT_TEXTURE_MATERIAL, Variant } from './variants'
@@ -161,7 +161,7 @@ export function convertToBlueprint() {
 	}
 	for (const animation of Blockbench.Animation.all) {
 		animation.createUniqueName(Blockbench.Animation.all.filter(a => a !== animation))
-		animation.name = toSafeFuntionName(animation.name)
+		animation.name = toSafeFunctionName(animation.name)
 	}
 	for (const cube of Cube.all) {
 		cube.setUVMode(false)
@@ -324,7 +324,7 @@ export const BLUEPRINT_CODEC = new Blockbench.Codec('animated_java_blueprint', {
 			parseGroups(model.outliner)
 
 			for (const group of Group.all) {
-				group.name = toSafeFuntionName(group.name)
+				group.name = toSafeFunctionName(group.name)
 			}
 		}
 

--- a/src/blueprintSettings.ts
+++ b/src/blueprintSettings.ts
@@ -5,6 +5,7 @@ export type ExportMode = 'raw' | 'zip' | 'none'
 
 export const defaultValues = {
 	export_namespace: 'blueprint',
+	export_safe_namespace: 'blueprint',
 	show_bounding_box: false,
 	auto_bounding_box: true,
 	bounding_box: [48, 48],

--- a/src/components/blueprintSettingsDialog.svelte
+++ b/src/components/blueprintSettingsDialog.svelte
@@ -74,7 +74,7 @@
 				type: 'error',
 				message: translate('dialog.blueprint_settings.export_namespace.error.empty'),
 			}
-		} else if (value.trim().match('[^a-zA-Z0-9_]')) {
+		} else if (value.trim().match('[^a-zA-Z0-9_\/]')) {
 			return {
 				type: 'error',
 				message: translate(

--- a/src/interface/dialog/blueprintSettings.ts
+++ b/src/interface/dialog/blueprintSettings.ts
@@ -2,7 +2,7 @@ import { PACKAGE } from '../../constants'
 import { SvelteDialog } from '../../util/svelteDialog'
 import { Valuable } from '../../util/stores'
 import BlueprintSettingsDialogSvelteComponent from '../../components/blueprintSettingsDialog.svelte'
-import { toSafeFuntionName } from '../../util/minecraftUtil'
+import { toSafeFunctionName, toSafeTagName } from '../../util/minecraftUtil'
 import { defaultValues, ExportMode } from '../../blueprintSettings'
 import { translate } from '../../util/translation'
 import { updateBoundingBox } from '../../blueprintFormat'
@@ -28,7 +28,13 @@ function getSettings() {
 			if (!value) {
 				return defaultValues.export_namespace
 			}
-			return toSafeFuntionName(value)
+			return toSafeFunctionName(value)
+		}),
+		exportSafeNamespace: new Valuable(Project!.animated_java.export_namespace, value => {
+			if (!value) {
+				return defaultValues.export_safe_namespace
+			}
+			return toSafeTagName(value)
 		}),
 		resourcePackExportMode: new Valuable(
 			Project!.animated_java.resource_pack_export_mode as string
@@ -81,6 +87,7 @@ function setSettings(settings: ReturnType<typeof getSettings>) {
 	Project.animated_java.enable_plugin_mode = settings.enablePluginMode.get()
 	Project.pluginMode.set(settings.enablePluginMode.get()) // Required to update the project title.
 	Project.animated_java.export_namespace = settings.exportNamespace.get()
+	Project.animated_java.export_safe_namespace = settings.exportSafeNamespace.get()
 	Project.animated_java.resource_pack_export_mode =
 		settings.resourcePackExportMode.get() as ExportMode
 	Project.animated_java.data_pack_export_mode = settings.dataPackExportMode.get() as ExportMode

--- a/src/interface/importAJModelLoader.ts
+++ b/src/interface/importAJModelLoader.ts
@@ -7,7 +7,7 @@ import { translate } from '../util/translation'
 import { openUnexpectedErrorDialog } from './dialog/unexpectedError'
 import * as ModelDatFixerUpper from '../systems/modelDataFixerUpper'
 import { BLUEPRINT_CODEC, IBlueprintFormatJSON } from '../blueprintFormat'
-import { toSafeFuntionName } from '../util/minecraftUtil'
+import { toSafeFunctionName } from '../util/minecraftUtil'
 
 let activeComponent: SvelteComponentDev | null = null
 
@@ -52,7 +52,7 @@ export function convertAJModelToBlueprint(path: string) {
 			name: 'Upgrade .ajmodel to Blueprint',
 			path,
 		})
-		blueprint.blueprint_settings!.export_namespace ??= toSafeFuntionName(Project!.name)
+		blueprint.blueprint_settings!.export_namespace ??= toSafeFunctionName(Project!.name)
 
 		requestAnimationFrame(() => {
 			Project!.save_path = ''

--- a/src/outliner/util.ts
+++ b/src/outliner/util.ts
@@ -1,10 +1,10 @@
-import { toSafeFuntionName } from '../util/minecraftUtil'
+import { toSafeFunctionName } from '../util/minecraftUtil'
 import { TextDisplay } from './textDisplay'
 import { VanillaBlockDisplay } from './vanillaBlockDisplay'
 import { VanillaItemDisplay } from './vanillaItemDisplay'
 
 export function sanitizeOutlinerElementName(name: string, elementUUID: string): string {
-	name = toSafeFuntionName(name)
+	name = toSafeFunctionName(name)
 	let otherNodes: OutlinerElement[] = [
 		...VanillaBlockDisplay.all,
 		...Group.all,

--- a/src/systems/animationRenderer.ts
+++ b/src/systems/animationRenderer.ts
@@ -8,7 +8,7 @@ import {
 import { TextDisplay } from '../outliner/textDisplay'
 import { VanillaBlockDisplay } from '../outliner/vanillaBlockDisplay'
 import { VanillaItemDisplay } from '../outliner/vanillaItemDisplay'
-import { toSafeFuntionName } from '../util/minecraftUtil'
+import { toSafeFunctionName } from '../util/minecraftUtil'
 import { eulerFromQuaternion, roundToNth } from '../util/misc'
 import { AnyRenderedNode, IRenderedRig } from './rigRenderer'
 import * as crypto from 'crypto'
@@ -303,7 +303,7 @@ export function renderAnimation(animation: _Animation, rig: IRenderedRig) {
 	const rendered = {
 		name: animation.name,
 		uuid: animation.uuid,
-		safe_name: toSafeFuntionName(animation.name).replaceAll('.', '_'),
+		safe_name: toSafeFunctionName(animation.name).replaceAll('.', '_'),
 		loop_delay: Number(animation.loop_delay) || 0,
 		frames: [],
 		duration: 0,

--- a/src/systems/datapackCompiler/1.20.4/animation.mcb
+++ b/src/systems/datapackCompiler/1.20.4/animation.mcb
@@ -3,7 +3,7 @@ dir <%export_namespace%> {
 	function on_load {
 		IF (use_storage_for_animation) {
 			REPEAT (animations) as animation {
-				data remove storage aj.<%export_namespace%>:animations <%animation.safe_name%>
+				data remove storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>
 			}
 			<%animationStorage.join('\n')%>
 		}
@@ -21,8 +21,8 @@ dir <%export_namespace%> {
 	dir root {
 		IF (show_outdated_warning) {
 			function on_load {
-				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] \
+				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] \
 						unless data entity @s {data:{rigHash: '<%rigHash%>'}} on vehicle run {
 					execute store result storage aj:temp x int 1 store result score #this.x aj.i run data get entity @s Pos[0] 1
 					execute store result storage aj:temp y int 1 store result score #this.y aj.i run data get entity @s Pos[1] 1
@@ -40,7 +40,7 @@ dir <%export_namespace%> {
 			}
 		}
 		function on_tick {
-			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
+			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
 			IF (show_outdated_warning) {
 				execute unless score @s <%OBJECTIVES.IS_RIG_LOADED()%> matches 1 run function #*global/root/on_load
 			}
@@ -48,11 +48,11 @@ dir <%export_namespace%> {
 			function #*<%export_namespace%>/as_root/pre_tick
 			# Animations
 			REPEAT (animations) as animation {
-				execute if entity @s[tag=<%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>] run \
+				execute if entity @s[tag=<%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>] run \
 					function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/on_tick
 			}
 			IF (has_locators || has_cameras) {
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] run {
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] run {
 					REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as node {
 						IF (node.config?.use_entity) {
 							block { with entity @s data.locators.<%node.safe_name%>
@@ -120,11 +120,11 @@ dir <%export_namespace%> {
 				# TODO: Maybe add an exclusive argument to the play function that will pause all other animations before playing this one.
 				function play {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/play'}
 					}
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> 0
 					tag @s add <%TAGS.TRANSFORMS_ONLY()%>
 					execute at @s run function ./zzz/set_frame {frame: 0}
@@ -132,11 +132,11 @@ dir <%export_namespace%> {
 				}
 				function stop {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/stop'}
 					}
-					tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> 0
 					tag @s add <%TAGS.TRANSFORMS_ONLY()%>
 					execute at @s run function ./zzz/set_frame {frame: 0}
@@ -144,23 +144,23 @@ dir <%export_namespace%> {
 				}
 				function pause {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/pause'}
 					}
-					tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 				}
 				function resume {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/resume'}
 					}
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 				}
 				function next_frame {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/next_frame'}
 					}
@@ -173,7 +173,7 @@ dir <%export_namespace%> {
 					# Sets the frame without interpolation
 					#ARGS: {frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/set_frame'}
 					}
@@ -183,7 +183,7 @@ dir <%export_namespace%> {
 				function apply_frame {
 					# ARGS: {frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/apply_frame'}
 					}
@@ -194,13 +194,13 @@ dir <%export_namespace%> {
 					# Attempts to smoothly transition from the currently playing animation into this one.
 					#ARGS: {duration: int, to_frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/tween'}
 					}
 					function *<%export_namespace%>/animations/pause_all
 
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					$scoreboard players set @s <%OBJECTIVES.TWEEN_DURATION()%> $(duration)
 					$scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> $(to_frame)
 
@@ -243,17 +243,17 @@ dir <%export_namespace%> {
 							#ARGS: {frame: int}
 							REPEAT (Object.values(animation.modified_nodes).sort(nodeSorter)) as node {
 								IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-									$execute on passengers run data modify entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, node.safe_name)%>] {} merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+									$execute on passengers run data modify entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, node.safe_name)%>] {} merge from \
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								} ELSE IF (['locator', 'camera'].includes(node.type)) {
 									$execute on passengers if entity @s[tag=<%TAGS.GLOBAL_DATA()%>] run data modify entity @s data.<%node.type + 's.' + node.safe_name%> merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								}
 							}
 							IF (animation.frames.some(v => v.variant)) {
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
 							}
 							execute on passengers run data modify entity @s[type=!marker] start_interpolation set value -1
 						}
@@ -261,17 +261,17 @@ dir <%export_namespace%> {
 							#ARGS: {frame: int}
 							REPEAT (Object.values(animation.modified_nodes).sort(nodeSorter)) as node {
 								IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-									$execute on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, node.safe_name)%>] run data modify entity @s {} merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+									$execute on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, node.safe_name)%>] run data modify entity @s {} merge from \
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								} ELSE IF (['locator', 'camera'].includes(node.type)) {
 									$execute on passengers if entity @s[tag=<%TAGS.GLOBAL_DATA()%>] run data modify entity @s data.<%node.type + 's.' + node.safe_name%> merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								}
 							}
 							IF (animation.frames.some(v => v.variant)) {
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
 							}
 						}
 						IF (animation.frames.some(v => v.variant)) {
@@ -398,11 +398,11 @@ dir <%export_namespace%> {
 		}
 		function pause_all {
 			# Pauses all animations
-			execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+			execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 				function *global/errors/function_not_executed_as_root_entity \
 					{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/pause_all'}
 			REPEAT (animations) as animation {
-				tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+				tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 			}
 		}
 	}
@@ -415,7 +415,7 @@ dir <%export_namespace%> {
 		$execute store success score #success <%OBJECTIVES.I()%> run data modify storage aj:temp args set value $(args)
 
 		summon minecraft:item_display ~ ~ ~ { \
-			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_namespace)%>'], \
+			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_safe_namespace)%>'], \
 			teleport_duration: 0, \
 			interpolation_duration: <%interpolation_duration%>, \
 			Passengers:<%root_entity_passengers%>, \
@@ -429,7 +429,7 @@ dir <%export_namespace%> {
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as locator {
 					IF (locator.config && locator.config.use_entity) {
-						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_namespace, locator.name)%>']}
+						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_safe_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_safe_namespace, locator.name)%>']}
 						execute as @e[type=<%locator.config.entity_type%>,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_LOCATOR()%>,limit=1,distance=..0.01] run {
 							tag @s remove <%TAGS.NEW()%>
 
@@ -445,7 +445,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'camera')) as camera {
-					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_namespace, camera.name)%>'], teleport_duration: 2}
+					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace, camera.name)%>'], teleport_duration: 2}
 					execute as @e[type=item_display,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_CAMERA()%>,limit=1,distance=..0.01] run {
 						tag @s remove <%TAGS.NEW()%>
 
@@ -455,7 +455,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => ['bone', 'text_display', 'item_display', 'block_display'].includes(v.type))) as bone {
-					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, bone.name)%>] run \
+					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, bone.name)%>] run \
 						function *global/internal/gu/convert_uuid_array_to_string with entity @s
 					data modify entity @s data.bones.<%bone.type + '_' + bone.name%> set from storage aj:uuid main.out
 				}
@@ -539,7 +539,7 @@ dir <%export_namespace%> {
 		function as_own_locator_entities {
 			#ARGS: {command: string}
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/as_all_locators'}
 			}
@@ -558,12 +558,12 @@ dir <%export_namespace%> {
 	dir remove {
 		# Removes all instances of this rig from the world.
 		function all {
-			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run function *<%export_namespace%>/remove/this
+			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run function *<%export_namespace%>/remove/this
 		}
 		# Removes the rig this function is executed as.
 		function this {
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/remove/this'}
 			}
@@ -600,12 +600,12 @@ dir <%export_namespace%> {
 			REPEAT (Object.values(rig.variants)) as variant {
 				dir <%variant.name%> {
 					function apply {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/variants/<%variant.name%>/apply'}
 						REPEAT (Object.values(rig.nodes)) as node {
 							IF (node.type === 'bone' && !variant.excluded_nodes.includes(node.uuid) && (variant.models[node.uuid] !== undefined || node.configs.variants[variant.uuid] !== undefined)) {
-								execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run {
+								execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run {
 									IF (variant.models[node.uuid] !== undefined) {
 										IF (variant.models[node.uuid].model === null) {
 											data modify entity @s item.tag.CustomModelData set value 1
@@ -632,12 +632,12 @@ dir <%export_namespace%> {
 
 	function apply_default_pose {
 		# Changes the pose of the rig to the the default pose with interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/apply_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: 0}
 			}
 		}
@@ -645,12 +645,12 @@ dir <%export_namespace%> {
 
 	function set_default_pose {
 		# Changes the pose of the rig to the the default pose without interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/set_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: -1}
 			}
 		}

--- a/src/systems/datapackCompiler/1.20.4/static.mcb
+++ b/src/systems/datapackCompiler/1.20.4/static.mcb
@@ -7,8 +7,8 @@ dir <%export_namespace%> {
 	dir root {
 		IF (show_outdated_warning) {
 			function on_load {
-				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] \
+				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] \
 						unless data entity @s {data:{rigHash: '<%rigHash%>'}} on vehicle run {
 					execute store result storage aj:temp x int 1 store result score #this.x aj.i run data get entity @s Pos[0] 1
 					execute store result storage aj:temp y int 1 store result score #this.y aj.i run data get entity @s Pos[1] 1
@@ -26,14 +26,14 @@ dir <%export_namespace%> {
 			}
 		}
 		function on_tick {
-			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
+			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
 			IF (show_outdated_warning) {
 				execute unless score @s <%OBJECTIVES.IS_RIG_LOADED()%> matches 1 run function #*global/root/on_load
 			}
 			# Pre tick
 			function #*<%export_namespace%>/as_root/pre_tick
 			IF (has_locators || has_cameras) {
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] run {
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] run {
 					REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as node {
 						IF (node.config?.use_entity) {
 							block { with entity @s data.locators.<%node.safe_name%>
@@ -102,7 +102,7 @@ dir <%export_namespace%> {
 		$execute store success score #success <%OBJECTIVES.I()%> run data modify storage aj:temp args set value $(args)
 
 		summon minecraft:item_display ~ ~ ~ { \
-			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_namespace)%>'], \
+			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_safe_namespace)%>'], \
 			teleport_duration: 0, \
 			interpolation_duration: <%interpolation_duration%>, \
 			Passengers:<%root_entity_passengers%>, \
@@ -116,7 +116,7 @@ dir <%export_namespace%> {
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as locator {
 					IF (locator.config && locator.config.use_entity) {
-						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_namespace, locator.name)%>']}
+						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_safe_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_safe_namespace, locator.name)%>']}
 						execute as @e[type=<%locator.config.entity_type%>,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_LOCATOR()%>,limit=1,distance=..0.01] run {
 							tag @s remove <%TAGS.NEW()%>
 
@@ -138,7 +138,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'camera')) as camera {
-					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_namespace, camera.name)%>'], teleport_duration: 2}
+					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace, camera.name)%>'], teleport_duration: 2}
 					execute as @e[type=item_display,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_CAMERA()%>,limit=1,distance=..0.01] run {
 						tag @s remove <%TAGS.NEW()%>
 
@@ -154,7 +154,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => ['bone', 'text_display', 'item_display', 'block_display'].includes(v.type))) as bone {
-					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, bone.name)%>] run \
+					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, bone.name)%>] run \
 						function *global/internal/gu/convert_uuid_array_to_string with entity @s
 					data modify entity @s data.bones.<%bone.type + '_' + bone.name%> set from storage aj:uuid main.out
 				}
@@ -208,7 +208,7 @@ dir <%export_namespace%> {
 		function as_own_locator_entities {
 			#ARGS: {command: string}
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/as_all_locators'}
 			}
@@ -227,12 +227,12 @@ dir <%export_namespace%> {
 	dir remove {
 		# Removes all instances of this rig from the world.
 		function all {
-			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run function *<%export_namespace%>/remove/this
+			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run function *<%export_namespace%>/remove/this
 		}
 		# Removes the rig this function is executed as.
 		function this {
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/remove/this'}
 			}
@@ -270,13 +270,13 @@ dir <%export_namespace%> {
 				dir <%variant.name%> {
 					function apply {
 						IF (show_function_errors) {
-							execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+							execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 								function *global/errors/function_not_executed_as_root_entity \
 									{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/variants/<%variant.name%>/apply'}
 						}
 						REPEAT (Object.values(rig.nodes)) as node {
 							IF (node.type === 'bone' && !variant.excluded_nodes.includes(node.uuid) && (variant.models[node.uuid] !== undefined || node.configs.variants[variant.uuid] !== undefined)) {
-								execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run {
+								execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run {
 									IF (variant.models[node.uuid] !== undefined) {
 										IF (variant.models[node.uuid].model === null) {
 											data modify entity @s item.tag.CustomModelData set value 1
@@ -303,12 +303,12 @@ dir <%export_namespace%> {
 
 	function set_default_pose {
 		# Changes the pose of the rig to the the default pose without interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/set_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: -1}
 			}
 		}

--- a/src/systems/datapackCompiler/1.20.5/animation.mcb
+++ b/src/systems/datapackCompiler/1.20.5/animation.mcb
@@ -3,7 +3,7 @@ dir <%export_namespace%> {
 	function on_load {
 		IF (use_storage_for_animation) {
 			REPEAT (animations) as animation {
-				data remove storage aj.<%export_namespace%>:animations <%animation.safe_name%>
+				data remove storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>
 			}
 			<%animationStorage.join('\n')%>
 		}
@@ -21,8 +21,8 @@ dir <%export_namespace%> {
 	dir root {
 		IF (show_outdated_warning) {
 			function on_load {
-				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] \
+				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] \
 						unless data entity @s {data:{rigHash: '<%rigHash%>'}} on vehicle run {
 					execute store result storage aj:temp x int 1 store result score #this.x aj.i run data get entity @s Pos[0] 1
 					execute store result storage aj:temp y int 1 store result score #this.y aj.i run data get entity @s Pos[1] 1
@@ -40,7 +40,7 @@ dir <%export_namespace%> {
 			}
 		}
 		function on_tick {
-			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
+			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
 			IF (show_outdated_warning) {
 				execute unless score @s <%OBJECTIVES.IS_RIG_LOADED()%> matches 1 run function #*global/root/on_load
 			}
@@ -48,11 +48,11 @@ dir <%export_namespace%> {
 			function #*<%export_namespace%>/as_root/pre_tick
 			# Animations
 			REPEAT (animations) as animation {
-				execute if entity @s[tag=<%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>] run \
+				execute if entity @s[tag=<%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>] run \
 					function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/on_tick
 			}
 			IF (has_locators || has_cameras) {
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] run {
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] run {
 					REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as node {
 						IF (node.config?.use_entity) {
 							block { with entity @s data.locators.<%node.safe_name%>
@@ -120,11 +120,11 @@ dir <%export_namespace%> {
 				# TODO: Maybe add an exclusive argument to the play function that will pause all other animations before playing this one.
 				function play {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/play'}
 					}
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> 0
 					tag @s add <%TAGS.TRANSFORMS_ONLY()%>
 					execute at @s run function ./zzz/set_frame {frame: 0}
@@ -132,11 +132,11 @@ dir <%export_namespace%> {
 				}
 				function stop {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/stop'}
 					}
-					tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> 0
 					tag @s add <%TAGS.TRANSFORMS_ONLY()%>
 					execute at @s run function ./zzz/set_frame {frame: 0}
@@ -144,23 +144,23 @@ dir <%export_namespace%> {
 				}
 				function pause {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/pause'}
 					}
-					tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 				}
 				function resume {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/resume'}
 					}
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 				}
 				function next_frame {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/next_frame'}
 					}
@@ -173,7 +173,7 @@ dir <%export_namespace%> {
 					# Sets the frame without interpolation
 					#ARGS: {frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/set_frame'}
 					}
@@ -183,7 +183,7 @@ dir <%export_namespace%> {
 				function apply_frame {
 					# ARGS: {frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/apply_frame'}
 					}
@@ -194,13 +194,13 @@ dir <%export_namespace%> {
 					# Attempts to smoothly transition from the currently playing animation into this one.
 					#ARGS: {duration: int, to_frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/tween'}
 					}
 					function *<%export_namespace%>/animations/pause_all
 
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					$scoreboard players set @s <%OBJECTIVES.TWEEN_DURATION()%> $(duration)
 					$scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> $(to_frame)
 
@@ -243,17 +243,17 @@ dir <%export_namespace%> {
 							#ARGS: {frame: int}
 							REPEAT (Object.values(animation.modified_nodes).sort(nodeSorter)) as node {
 								IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-									$execute on passengers run data modify entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, node.safe_name)%>] {} merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+									$execute on passengers run data modify entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, node.safe_name)%>] {} merge from \
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								} ELSE IF (['locator', 'camera'].includes(node.type)) {
 									$execute on passengers if entity @s[tag=<%TAGS.GLOBAL_DATA()%>] run data modify entity @s data.<%node.type + 's.' + node.safe_name%> merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								}
 							}
 							IF (animation.frames.some(v => v.variant)) {
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
 							}
 							execute on passengers run data modify entity @s[type=!marker] start_interpolation set value -1
 						}
@@ -261,17 +261,17 @@ dir <%export_namespace%> {
 							#ARGS: {frame: int}
 							REPEAT (Object.values(animation.modified_nodes).sort(nodeSorter)) as node {
 								IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-									$execute on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, node.safe_name)%>] run data modify entity @s {} merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+									$execute on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, node.safe_name)%>] run data modify entity @s {} merge from \
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								} ELSE IF (['locator', 'camera'].includes(node.type)) {
 									$execute on passengers if entity @s[tag=<%TAGS.GLOBAL_DATA()%>] run data modify entity @s data.<%node.type + 's.' + node.safe_name%> merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								}
 							}
 							IF (animation.frames.some(v => v.variant)) {
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
 							}
 						}
 						IF (animation.frames.some(v => v.variant)) {
@@ -398,11 +398,11 @@ dir <%export_namespace%> {
 		}
 		function pause_all {
 			# Pauses all animations
-			execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+			execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 				function *global/errors/function_not_executed_as_root_entity \
 					{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/pause_all'}
 			REPEAT (animations) as animation {
-				tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+				tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 			}
 		}
 	}
@@ -415,7 +415,7 @@ dir <%export_namespace%> {
 		$execute store success score #success <%OBJECTIVES.I()%> run data modify storage aj:temp args set value $(args)
 
 		summon minecraft:item_display ~ ~ ~ { \
-			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_namespace)%>'], \
+			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_safe_namespace)%>'], \
 			teleport_duration: 0, \
 			interpolation_duration: <%interpolation_duration%>, \
 			Passengers:<%root_entity_passengers%>, \
@@ -429,7 +429,7 @@ dir <%export_namespace%> {
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as locator {
 					IF (locator.config && locator.config.use_entity) {
-						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_namespace, locator.name)%>']}
+						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_safe_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_safe_namespace, locator.name)%>']}
 						execute as @e[type=<%locator.config.entity_type%>,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_LOCATOR()%>,limit=1,distance=..0.01] run {
 							tag @s remove <%TAGS.NEW()%>
 
@@ -445,7 +445,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'camera')) as camera {
-					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_namespace, camera.name)%>'], teleport_duration: 2}
+					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace, camera.name)%>'], teleport_duration: 2}
 					execute as @e[type=item_display,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_CAMERA()%>,limit=1,distance=..0.01] run {
 						tag @s remove <%TAGS.NEW()%>
 
@@ -455,7 +455,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => ['bone', 'text_display', 'item_display', 'block_display'].includes(v.type))) as bone {
-					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, bone.name)%>] run \
+					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, bone.name)%>] run \
 						function *global/internal/gu/convert_uuid_array_to_string with entity @s
 					data modify entity @s data.bones.<%bone.type + '_' + bone.name%> set from storage aj:uuid main.out
 				}
@@ -539,7 +539,7 @@ dir <%export_namespace%> {
 		function as_own_locator_entities {
 			#ARGS: {command: string}
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/as_all_locators'}
 			}
@@ -558,12 +558,12 @@ dir <%export_namespace%> {
 	dir remove {
 		# Removes all instances of this rig from the world.
 		function all {
-			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run function *<%export_namespace%>/remove/this
+			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run function *<%export_namespace%>/remove/this
 		}
 		# Removes the rig this function is executed as.
 		function this {
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/remove/this'}
 			}
@@ -600,12 +600,12 @@ dir <%export_namespace%> {
 			REPEAT (Object.values(rig.variants)) as variant {
 				dir <%variant.name%> {
 					function apply {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/variants/<%variant.name%>/apply'}
 						REPEAT (Object.values(rig.nodes)) as node {
 							IF (node.type === 'bone' && !variant.excluded_nodes.includes(node.uuid) && (variant.models[node.uuid] !== undefined || node.configs.variants[variant.uuid] !== undefined)) {
-								execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run {
+								execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run {
 									IF (variant.models[node.uuid] !== undefined) {
 										IF (variant.models[node.uuid].model === null) {
 											data modify entity @s item.components.minecraft:custom_model_data set value 1
@@ -632,12 +632,12 @@ dir <%export_namespace%> {
 
 	function apply_default_pose {
 		# Changes the pose of the rig to the the default pose with interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/apply_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: 0}
 			}
 		}
@@ -645,12 +645,12 @@ dir <%export_namespace%> {
 
 	function set_default_pose {
 		# Changes the pose of the rig to the the default pose without interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/set_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: -1}
 			}
 		}

--- a/src/systems/datapackCompiler/1.20.5/static.mcb
+++ b/src/systems/datapackCompiler/1.20.5/static.mcb
@@ -7,8 +7,8 @@ dir <%export_namespace%> {
 	dir root {
 		IF (show_outdated_warning) {
 			function on_load {
-				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] \
+				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] \
 						unless data entity @s {data:{rigHash: '<%rigHash%>'}} on vehicle run {
 					execute store result storage aj:temp x int 1 store result score #this.x aj.i run data get entity @s Pos[0] 1
 					execute store result storage aj:temp y int 1 store result score #this.y aj.i run data get entity @s Pos[1] 1
@@ -26,14 +26,14 @@ dir <%export_namespace%> {
 			}
 		}
 		function on_tick {
-			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
+			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
 			IF (show_outdated_warning) {
 				execute unless score @s <%OBJECTIVES.IS_RIG_LOADED()%> matches 1 run function #*global/root/on_load
 			}
 			# Pre tick
 			function #*<%export_namespace%>/as_root/pre_tick
 			IF (has_locators || has_cameras) {
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] run {
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] run {
 					REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as node {
 						IF (node.config?.use_entity) {
 							block { with entity @s data.locators.<%node.safe_name%>
@@ -102,7 +102,7 @@ dir <%export_namespace%> {
 		$execute store success score #success <%OBJECTIVES.I()%> run data modify storage aj:temp args set value $(args)
 
 		summon minecraft:item_display ~ ~ ~ { \
-			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_namespace)%>'], \
+			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_safe_namespace)%>'], \
 			teleport_duration: 0, \
 			interpolation_duration: <%interpolation_duration%>, \
 			Passengers:<%root_entity_passengers%>, \
@@ -116,7 +116,7 @@ dir <%export_namespace%> {
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as locator {
 					IF (locator.config && locator.config.use_entity) {
-						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_namespace, locator.name)%>']}
+						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_safe_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_safe_namespace, locator.name)%>']}
 						execute as @e[type=<%locator.config.entity_type%>,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_LOCATOR()%>,limit=1,distance=..0.01] run {
 							tag @s remove <%TAGS.NEW()%>
 
@@ -138,7 +138,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'camera')) as camera {
-					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_namespace, camera.name)%>'], teleport_duration: 2}
+					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace, camera.name)%>'], teleport_duration: 2}
 					execute as @e[type=item_display,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_CAMERA()%>,limit=1,distance=..0.01] run {
 						tag @s remove <%TAGS.NEW()%>
 
@@ -154,7 +154,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => ['bone', 'text_display', 'item_display', 'block_display'].includes(v.type))) as bone {
-					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, bone.name)%>] run \
+					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, bone.name)%>] run \
 						function *global/internal/gu/convert_uuid_array_to_string with entity @s
 					data modify entity @s data.bones.<%bone.type + '_' + bone.name%> set from storage aj:uuid main.out
 				}
@@ -208,7 +208,7 @@ dir <%export_namespace%> {
 		function as_own_locator_entities {
 			#ARGS: {command: string}
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/as_all_locators'}
 			}
@@ -227,12 +227,12 @@ dir <%export_namespace%> {
 	dir remove {
 		# Removes all instances of this rig from the world.
 		function all {
-			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run function *<%export_namespace%>/remove/this
+			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run function *<%export_namespace%>/remove/this
 		}
 		# Removes the rig this function is executed as.
 		function this {
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/remove/this'}
 			}
@@ -270,13 +270,13 @@ dir <%export_namespace%> {
 				dir <%variant.name%> {
 					function apply {
 						IF (show_function_errors) {
-							execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+							execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 								function *global/errors/function_not_executed_as_root_entity \
 									{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/variants/<%variant.name%>/apply'}
 						}
 						REPEAT (Object.values(rig.nodes)) as node {
 							IF (node.type === 'bone' && !variant.excluded_nodes.includes(node.uuid) && (variant.models[node.uuid] !== undefined || node.configs.variants[variant.uuid] !== undefined)) {
-								execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run {
+								execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run {
 									IF (variant.models[node.uuid] !== undefined) {
 										IF (variant.models[node.uuid].model === null) {
 											data modify entity @s item.components.minecraft:custom_model_data set value 1
@@ -303,12 +303,12 @@ dir <%export_namespace%> {
 
 	function set_default_pose {
 		# Changes the pose of the rig to the the default pose without interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/set_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: -1}
 			}
 		}

--- a/src/systems/datapackCompiler/1.21.2/animation.mcb
+++ b/src/systems/datapackCompiler/1.21.2/animation.mcb
@@ -3,7 +3,7 @@ dir <%export_namespace%> {
 	function on_load {
 		IF (use_storage_for_animation) {
 			REPEAT (animations) as animation {
-				data remove storage aj.<%export_namespace%>:animations <%animation.safe_name%>
+				data remove storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>
 			}
 			<%animationStorage.join('\n')%>
 		}
@@ -21,8 +21,8 @@ dir <%export_namespace%> {
 	dir root {
 		IF (show_outdated_warning) {
 			function on_load {
-				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] \
+				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] \
 						unless data entity @s {data:{rigHash: '<%rigHash%>'}} on vehicle run {
 					execute store result storage aj:temp x int 1 store result score #this.x aj.i run data get entity @s Pos[0] 1
 					execute store result storage aj:temp y int 1 store result score #this.y aj.i run data get entity @s Pos[1] 1
@@ -40,7 +40,7 @@ dir <%export_namespace%> {
 			}
 		}
 		function on_tick {
-			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
+			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
 			IF (show_outdated_warning) {
 				execute unless score @s <%OBJECTIVES.IS_RIG_LOADED()%> matches 1 run function #*global/root/on_load
 			}
@@ -48,11 +48,11 @@ dir <%export_namespace%> {
 			function #*<%export_namespace%>/as_root/pre_tick
 			# Animations
 			REPEAT (animations) as animation {
-				execute if entity @s[tag=<%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>] run \
+				execute if entity @s[tag=<%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>] run \
 					function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/on_tick
 			}
 			IF (has_locators || has_cameras) {
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] run {
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] run {
 					REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as node {
 						IF (node.config?.use_entity) {
 							block { with entity @s data.locators.<%node.safe_name%>
@@ -120,11 +120,11 @@ dir <%export_namespace%> {
 				# TODO: Maybe add an exclusive argument to the play function that will pause all other animations before playing this one.
 				function play {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/play'}
 					}
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> 0
 					tag @s add <%TAGS.TRANSFORMS_ONLY()%>
 					execute at @s run function ./zzz/set_frame {frame: 0}
@@ -132,11 +132,11 @@ dir <%export_namespace%> {
 				}
 				function stop {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/stop'}
 					}
-					tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> 0
 					tag @s add <%TAGS.TRANSFORMS_ONLY()%>
 					execute at @s run function ./zzz/set_frame {frame: 0}
@@ -144,23 +144,23 @@ dir <%export_namespace%> {
 				}
 				function pause {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/pause'}
 					}
-					tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 				}
 				function resume {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/resume'}
 					}
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 				}
 				function next_frame {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/next_frame'}
 					}
@@ -173,7 +173,7 @@ dir <%export_namespace%> {
 					# Sets the frame without interpolation
 					#ARGS: {frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/set_frame'}
 					}
@@ -183,7 +183,7 @@ dir <%export_namespace%> {
 				function apply_frame {
 					# ARGS: {frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/apply_frame'}
 					}
@@ -194,13 +194,13 @@ dir <%export_namespace%> {
 					# Attempts to smoothly transition from the currently playing animation into this one.
 					#ARGS: {duration: int, to_frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/tween'}
 					}
 					function *<%export_namespace%>/animations/pause_all
 
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					$scoreboard players set @s <%OBJECTIVES.TWEEN_DURATION()%> $(duration)
 					$scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> $(to_frame)
 
@@ -243,17 +243,17 @@ dir <%export_namespace%> {
 							#ARGS: {frame: int}
 							REPEAT (Object.values(animation.modified_nodes).sort(nodeSorter)) as node {
 								IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-									$execute on passengers run data modify entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, node.safe_name)%>] {} merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+									$execute on passengers run data modify entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, node.safe_name)%>] {} merge from \
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								} ELSE IF (['locator', 'camera'].includes(node.type)) {
 									$execute on passengers if entity @s[tag=<%TAGS.GLOBAL_DATA()%>] run data modify entity @s data.<%node.type + 's.' + node.safe_name%> merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								}
 							}
 							IF (animation.frames.some(v => v.variant)) {
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
 							}
 							execute on passengers run data modify entity @s[type=!marker] start_interpolation set value -1
 						}
@@ -261,17 +261,17 @@ dir <%export_namespace%> {
 							#ARGS: {frame: int}
 							REPEAT (Object.values(animation.modified_nodes).sort(nodeSorter)) as node {
 								IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-									$execute on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, node.safe_name)%>] run data modify entity @s {} merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+									$execute on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, node.safe_name)%>] run data modify entity @s {} merge from \
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								} ELSE IF (['locator', 'camera'].includes(node.type)) {
 									$execute on passengers if entity @s[tag=<%TAGS.GLOBAL_DATA()%>] run data modify entity @s data.<%node.type + 's.' + node.safe_name%> merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								}
 							}
 							IF (animation.frames.some(v => v.variant)) {
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
-								$execute if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data modify storage aj:temp variant set from storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/apply_variant with storage aj:temp variant
+								$execute if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] run data remove storage aj:temp variant
 							}
 						}
 						IF (animation.frames.some(v => v.variant)) {
@@ -398,11 +398,11 @@ dir <%export_namespace%> {
 		}
 		function pause_all {
 			# Pauses all animations
-			execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+			execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 				function *global/errors/function_not_executed_as_root_entity \
 					{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/pause_all'}
 			REPEAT (animations) as animation {
-				tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+				tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 			}
 		}
 	}
@@ -415,7 +415,7 @@ dir <%export_namespace%> {
 		$execute store success score #success <%OBJECTIVES.I()%> run data modify storage aj:temp args set value $(args)
 
 		summon minecraft:item_display ~ ~ ~ { \
-			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_namespace)%>'], \
+			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_safe_namespace)%>'], \
 			teleport_duration: 0, \
 			interpolation_duration: <%interpolation_duration%>, \
 			Passengers:<%root_entity_passengers%>, \
@@ -429,7 +429,7 @@ dir <%export_namespace%> {
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as locator {
 					IF (locator.config && locator.config.use_entity) {
-						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_namespace, locator.name)%>']}
+						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_safe_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_safe_namespace, locator.name)%>']}
 						execute as @e[type=<%locator.config.entity_type%>,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_LOCATOR()%>,limit=1,distance=..0.01] run {
 							tag @s remove <%TAGS.NEW()%>
 
@@ -445,7 +445,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'camera')) as camera {
-					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_namespace, camera.name)%>'], teleport_duration: 2}
+					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace, camera.name)%>'], teleport_duration: 2}
 					execute as @e[type=item_display,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_CAMERA()%>,limit=1,distance=..0.01] run {
 						tag @s remove <%TAGS.NEW()%>
 
@@ -455,7 +455,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => ['bone', 'text_display', 'item_display', 'block_display'].includes(v.type))) as bone {
-					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, bone.name)%>] run \
+					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, bone.name)%>] run \
 						function *global/internal/gu/convert_uuid_array_to_string with entity @s
 					data modify entity @s data.bones.<%bone.type + '_' + bone.name%> set from storage aj:uuid main.out
 				}
@@ -539,7 +539,7 @@ dir <%export_namespace%> {
 		function as_own_locator_entities {
 			#ARGS: {command: string}
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/as_all_locators'}
 			}
@@ -558,12 +558,12 @@ dir <%export_namespace%> {
 	dir remove {
 		# Removes all instances of this rig from the world.
 		function all {
-			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run function *<%export_namespace%>/remove/this
+			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run function *<%export_namespace%>/remove/this
 		}
 		# Removes the rig this function is executed as.
 		function this {
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/remove/this'}
 			}
@@ -600,12 +600,12 @@ dir <%export_namespace%> {
 			REPEAT (Object.values(rig.variants)) as variant {
 				dir <%variant.name%> {
 					function apply {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/variants/<%variant.name%>/apply'}
 						REPEAT (Object.values(rig.nodes)) as node {
 							IF (node.type === 'bone' && !variant.excluded_nodes.includes(node.uuid) && (variant.models[node.uuid] !== undefined || node.configs.variants[variant.uuid] !== undefined)) {
-								execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run {
+								execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run {
 									IF (variant.models[node.uuid] !== undefined) {
 										IF (variant.models[node.uuid].model === null) {
 											data modify entity @s item.components.minecraft:item_model set value "animated_java:empty"
@@ -632,12 +632,12 @@ dir <%export_namespace%> {
 
 	function apply_default_pose {
 		# Changes the pose of the rig to the the default pose with interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/apply_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: 0}
 			}
 		}
@@ -645,12 +645,12 @@ dir <%export_namespace%> {
 
 	function set_default_pose {
 		# Changes the pose of the rig to the the default pose without interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/set_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: -1}
 			}
 		}

--- a/src/systems/datapackCompiler/1.21.2/static.mcb
+++ b/src/systems/datapackCompiler/1.21.2/static.mcb
@@ -7,8 +7,8 @@ dir <%export_namespace%> {
 	dir root {
 		IF (show_outdated_warning) {
 			function on_load {
-				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] \
+				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] \
 						unless data entity @s {data:{rigHash: '<%rigHash%>'}} on vehicle run {
 					execute store result storage aj:temp x int 1 store result score #this.x aj.i run data get entity @s Pos[0] 1
 					execute store result storage aj:temp y int 1 store result score #this.y aj.i run data get entity @s Pos[1] 1
@@ -26,14 +26,14 @@ dir <%export_namespace%> {
 			}
 		}
 		function on_tick {
-			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
+			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
 			IF (show_outdated_warning) {
 				execute unless score @s <%OBJECTIVES.IS_RIG_LOADED()%> matches 1 run function #*global/root/on_load
 			}
 			# Pre tick
 			function #*<%export_namespace%>/as_root/pre_tick
 			IF (has_locators || has_cameras) {
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] run {
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] run {
 					REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as node {
 						IF (node.config?.use_entity) {
 							block { with entity @s data.locators.<%node.safe_name%>
@@ -102,7 +102,7 @@ dir <%export_namespace%> {
 		$execute store success score #success <%OBJECTIVES.I()%> run data modify storage aj:temp args set value $(args)
 
 		summon minecraft:item_display ~ ~ ~ { \
-			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_namespace)%>'], \
+			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_safe_namespace)%>'], \
 			teleport_duration: 0, \
 			interpolation_duration: <%interpolation_duration%>, \
 			Passengers:<%root_entity_passengers%>, \
@@ -116,7 +116,7 @@ dir <%export_namespace%> {
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as locator {
 					IF (locator.config && locator.config.use_entity) {
-						summon <%locator.config.entity_type%> ^<%locator.default_transform.pos[0]%> ^<%locator.default_transform.pos[1]%> ^<%locator.default_transform.pos[2]%> {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_namespace, locator.name)%>']}
+						summon <%locator.config.entity_type%> ^<%locator.default_transform.pos[0]%> ^<%locator.default_transform.pos[1]%> ^<%locator.default_transform.pos[2]%> {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_safe_namespace)%>', '<%TAGS.PROJECT_LOCATOR_NAMED(export_safe_namespace, locator.name)%>']}
 						execute as @e[type=<%locator.config.entity_type%>,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_LOCATOR()%>,limit=1,distance=..0.01] run {
 							tag @s remove <%TAGS.NEW()%>
 
@@ -138,7 +138,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'camera')) as camera {
-					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_namespace, camera.name)%>'], teleport_duration: 2}
+					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace, camera.name)%>'], teleport_duration: 2}
 					execute as @e[type=item_display,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_CAMERA()%>,limit=1,distance=..0.01] run {
 						tag @s remove <%TAGS.NEW()%>
 
@@ -154,7 +154,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => ['bone', 'text_display', 'item_display', 'block_display'].includes(v.type))) as bone {
-					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, bone.name)%>] run \
+					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, bone.name)%>] run \
 						function *global/internal/gu/convert_uuid_array_to_string with entity @s
 					data modify entity @s data.bones.<%bone.type + '_' + bone.name%> set from storage aj:uuid main.out
 				}
@@ -208,7 +208,7 @@ dir <%export_namespace%> {
 		function as_own_locator_entities {
 			#ARGS: {command: string}
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/as_all_locators'}
 			}
@@ -227,12 +227,12 @@ dir <%export_namespace%> {
 	dir remove {
 		# Removes all instances of this rig from the world.
 		function all {
-			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run function *<%export_namespace%>/remove/this
+			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run function *<%export_namespace%>/remove/this
 		}
 		# Removes the rig this function is executed as.
 		function this {
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/remove/this'}
 			}
@@ -270,13 +270,13 @@ dir <%export_namespace%> {
 				dir <%variant.name%> {
 					function apply {
 						IF (show_function_errors) {
-							execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+							execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 								function *global/errors/function_not_executed_as_root_entity \
 									{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/variants/<%variant.name%>/apply'}
 						}
 						REPEAT (Object.values(rig.nodes)) as node {
 							IF (node.type === 'bone' && !variant.excluded_nodes.includes(node.uuid) && (variant.models[node.uuid] !== undefined || node.configs.variants[variant.uuid] !== undefined)) {
-								execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run {
+								execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run {
 									IF (variant.models[node.uuid] !== undefined) {
 										IF (variant.models[node.uuid].model === null) {
 											data modify entity @s item.components.minecraft:item_model set value "animated_java:empty"
@@ -303,12 +303,12 @@ dir <%export_namespace%> {
 
 	function set_default_pose {
 		# Changes the pose of the rig to the the default pose without interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/set_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: -1}
 			}
 		}

--- a/src/systems/datapackCompiler/1.21.4/animation.mcb
+++ b/src/systems/datapackCompiler/1.21.4/animation.mcb
@@ -3,7 +3,7 @@ dir <%export_namespace%> {
 	function on_load {
 		IF (use_storage_for_animation) {
 			REPEAT (animations) as animation {
-				data remove storage aj.<%export_namespace%>:animations <%animation.safe_name%>
+				data remove storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>
 			}
 			<%animationStorage.join('\n')%>
 		}
@@ -21,8 +21,8 @@ dir <%export_namespace%> {
 	dir root {
 		IF (show_outdated_warning) {
 			function on_load {
-				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] \
+				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] \
 						unless data entity @s {data:{rigHash: '<%rigHash%>'}} on vehicle run {
 					execute store result storage aj:temp x int 1 store result score #this.x aj.i run data get entity @s Pos[0] 1
 					execute store result storage aj:temp y int 1 store result score #this.y aj.i run data get entity @s Pos[1] 1
@@ -40,7 +40,7 @@ dir <%export_namespace%> {
 			}
 		}
 		function on_tick {
-			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
+			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
 			IF (show_outdated_warning) {
 				execute unless score @s <%OBJECTIVES.IS_RIG_LOADED()%> matches 1 run function #*global/root/on_load
 			}
@@ -48,11 +48,11 @@ dir <%export_namespace%> {
 			function #*<%export_namespace%>/as_root/pre_tick
 			# Animations
 			REPEAT (animations) as animation {
-				execute if entity @s[tag=<%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>] run \
+				execute if entity @s[tag=<%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>] run \
 					function *<%export_namespace%>/animations/<%animation.safe_name%>/zzz/on_tick
 			}
 			IF (has_locators || has_cameras) {
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] run {
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] run {
 					REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as node {
 						IF (node.config?.use_entity) {
 							block { with entity @s data.locators.<%node.safe_name%>
@@ -120,11 +120,11 @@ dir <%export_namespace%> {
 				# TODO: Maybe add an exclusive argument to the play function that will pause all other animations before playing this one.
 				function play {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/play'}
 					}
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> 0
 					tag @s add <%TAGS.TRANSFORMS_ONLY()%>
 					execute at @s run function ./zzz/set_frame {frame: 0}
@@ -132,11 +132,11 @@ dir <%export_namespace%> {
 				}
 				function stop {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/stop'}
 					}
-					tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> 0
 					tag @s add <%TAGS.TRANSFORMS_ONLY()%>
 					execute at @s run function ./zzz/set_frame {frame: 0}
@@ -144,23 +144,23 @@ dir <%export_namespace%> {
 				}
 				function pause {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/pause'}
 					}
-					tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 				}
 				function resume {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/resume'}
 					}
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 				}
 				function next_frame {
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/next_frame'}
 					}
@@ -173,7 +173,7 @@ dir <%export_namespace%> {
 					# Sets the frame without interpolation
 					#ARGS: {frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/set_frame'}
 					}
@@ -183,7 +183,7 @@ dir <%export_namespace%> {
 				function apply_frame {
 					# ARGS: {frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/apply_frame'}
 					}
@@ -194,13 +194,13 @@ dir <%export_namespace%> {
 					# Attempts to smoothly transition from the currently playing animation into this one.
 					#ARGS: {duration: int, to_frame: int}
 					IF (show_function_errors) {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/<%animation.safe_name%>/tween'}
 					}
 					function *<%export_namespace%>/animations/pause_all
 
-					tag @s add <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+					tag @s add <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 					$scoreboard players set @s <%OBJECTIVES.TWEEN_DURATION()%> $(duration)
 					$scoreboard players set @s <%OBJECTIVES.FRAME(animation.safe_name)%> $(to_frame)
 
@@ -243,18 +243,18 @@ dir <%export_namespace%> {
 							#ARGS: {frame: int}
 							REPEAT (Object.values(animation.modified_nodes).sort(nodeSorter)) as node {
 								IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-									$execute on passengers run data modify entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, node.safe_name)%>] {} merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+									$execute on passengers run data modify entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, node.safe_name)%>] {} merge from \
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								} ELSE IF (['locator', 'camera'].includes(node.type)) {
 									$execute on passengers if entity @s[tag=<%TAGS.GLOBAL_DATA()%>] run data modify entity @s data.<%node.type + 's.' + node.safe_name%> merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								}
 							}
 							IF (animation.frames.some(v => v.variant)) {
 								$execute \
-									if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant \
+									if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant \
 									unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] \
-								run { with storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant
+								run { with storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant
 									#ARGS: {name: string, condition: string}
 									$execute $(condition)run function *<%export_namespace%>/variants/$(name)/apply
 								}
@@ -265,18 +265,18 @@ dir <%export_namespace%> {
 							#ARGS: {frame: int}
 							REPEAT (Object.values(animation.modified_nodes).sort(nodeSorter)) as node {
 								IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-									$execute on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, node.safe_name)%>] run data modify entity @s {} merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+									$execute on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, node.safe_name)%>] run data modify entity @s {} merge from \
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								} ELSE IF (['locator', 'camera'].includes(node.type)) {
 									$execute on passengers if entity @s[tag=<%TAGS.GLOBAL_DATA()%>] run data modify entity @s data.<%node.type + 's.' + node.safe_name%> merge from \
-										storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
+										storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).<%node.type + '_' + node.safe_name%>
 								}
 							}
 							IF (animation.frames.some(v => v.variant)) {
 								$execute \
-									if data storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant \
+									if data storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant \
 									unless entity @s[tag=<%TAGS.TRANSFORMS_ONLY()%>] \
-								run { with storage aj.<%export_namespace%>:animations <%animation.safe_name%>.$(frame).variant
+								run { with storage aj.<%export_safe_namespace%>:animations <%animation.safe_name%>.$(frame).variant
 									#ARGS: {name: string, condition: string}
 									$execute $(condition)run function *<%export_namespace%>/variants/$(name)/apply
 								}
@@ -400,11 +400,11 @@ dir <%export_namespace%> {
 		}
 		function pause_all {
 			# Pauses all animations
-			execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+			execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 				function *global/errors/function_not_executed_as_root_entity \
 					{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/animations/pause_all'}
 			REPEAT (animations) as animation {
-				tag @s remove <%TAGS.ANIMATION_PLAYING(export_namespace, animation.safe_name)%>
+				tag @s remove <%TAGS.ANIMATION_PLAYING(export_safe_namespace, animation.safe_name)%>
 			}
 		}
 	}
@@ -417,7 +417,7 @@ dir <%export_namespace%> {
 		$execute store success score #success <%OBJECTIVES.I()%> run data modify storage aj:temp args set value $(args)
 
 		summon minecraft:item_display ~ ~ ~ { \
-			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_namespace)%>'], \
+			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_safe_namespace)%>'], \
 			teleport_duration: 0, \
 			interpolation_duration: <%interpolation_duration%>, \
 			Passengers:<%root_entity_passengers%>, \
@@ -431,7 +431,7 @@ dir <%export_namespace%> {
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as locator {
 					IF (locator.config && locator.config.use_entity) {
-						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_namespace)%>', '<%TAGS.PROJECT_LOCATOR(export_namespace, locator.name)%>']}
+						summon <%locator.config.entity_type%> ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_LOCATOR()%>', '<%TAGS.PROJECT_LOCATOR(export_safe_namespace)%>', '<%TAGS.PROJECT_LOCATOR(export_safe_namespace, locator.name)%>']}
 						execute as @e[type=<%locator.config.entity_type%>,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_LOCATOR()%>,limit=1,distance=..0.01] run {
 							tag @s remove <%TAGS.NEW()%>
 
@@ -447,7 +447,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'camera')) as camera {
-					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_namespace, camera.name)%>'], teleport_duration: 2}
+					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace, camera.name)%>'], teleport_duration: 2}
 					execute as @e[type=item_display,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_CAMERA()%>,limit=1,distance=..0.01] run {
 						tag @s remove <%TAGS.NEW()%>
 						function *global/internal/gu/convert_uuid_array_to_string with entity @s
@@ -456,7 +456,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => ['bone', 'text_display', 'item_display', 'block_display'].includes(v.type))) as node {
-					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, node.name)%>] run \
+					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, node.name)%>] run \
 						function *global/internal/gu/convert_uuid_array_to_string with entity @s
 					data modify entity @s data.bones.<%node.type + '_' + node.name%> set from storage aj:uuid main.out
 				}
@@ -540,7 +540,7 @@ dir <%export_namespace%> {
 		function as_own_locator_entities {
 			#ARGS: {command: string}
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/as_all_locators'}
 			}
@@ -559,12 +559,12 @@ dir <%export_namespace%> {
 	dir remove {
 		# Removes all instances of this rig from the world.
 		function all {
-			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run function *<%export_namespace%>/remove/this
+			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run function *<%export_namespace%>/remove/this
 		}
 		# Removes the rig this function is executed as.
 		function this {
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/remove/this'}
 			}
@@ -601,12 +601,12 @@ dir <%export_namespace%> {
 			REPEAT (Object.values(rig.variants)) as variant {
 				dir <%variant.name%> {
 					function apply {
-						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+						execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 							function *global/errors/function_not_executed_as_root_entity \
 								{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/variants/<%variant.name%>/apply'}
 						REPEAT (Object.values(rig.nodes)) as node {
 							IF (node.type === 'bone' && !variant.excluded_nodes.includes(node.uuid) && (variant.models[node.uuid] !== undefined || node.configs.variants[variant.uuid] !== undefined)) {
-								execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run {
+								execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run {
 									IF (variant.models[node.uuid] !== undefined) {
 										data modify entity @s item.components.minecraft:custom_model_data.strings[0] set value "<%variant.name%>"
 									}
@@ -629,12 +629,12 @@ dir <%export_namespace%> {
 
 	function apply_default_pose {
 		# Changes the pose of the rig to the the default pose with interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/apply_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: 0}
 			}
 		}
@@ -642,12 +642,12 @@ dir <%export_namespace%> {
 
 	function set_default_pose {
 		# Changes the pose of the rig to the the default pose without interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/set_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: -1}
 			}
 		}

--- a/src/systems/datapackCompiler/1.21.4/static.mcb
+++ b/src/systems/datapackCompiler/1.21.4/static.mcb
@@ -7,8 +7,8 @@ dir <%export_namespace%> {
 	dir root {
 		IF (show_outdated_warning) {
 			function on_load {
-				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] \
+				execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] \
 						unless data entity @s {data:{rigHash: '<%rigHash%>'}} on vehicle run {
 					execute store result storage aj:temp x int 1 store result score #this.x aj.i run data get entity @s Pos[0] 1
 					execute store result storage aj:temp y int 1 store result score #this.y aj.i run data get entity @s Pos[1] 1
@@ -26,14 +26,14 @@ dir <%export_namespace%> {
 			}
 		}
 		function on_tick {
-			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return 0
+			execute unless entity @s[tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return 0
 			IF (show_outdated_warning) {
 				execute unless score @s <%OBJECTIVES.IS_RIG_LOADED()%> matches 1 run function #*global/root/on_load
 			}
 			# Pre tick
 			function #*<%export_namespace%>/as_root/pre_tick
 			IF (has_locators || has_cameras) {
-				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_namespace)%>] run {
+				execute on passengers if entity @s[tag=<%TAGS.PROJECT_DATA(export_safe_namespace)%>] run {
 					REPEAT (Object.values(rig.nodes).filter(v => v.type === 'locator')) as node {
 						IF (node.config?.use_entity) {
 							block { with entity @s data.locators.<%node.safe_name%>
@@ -102,7 +102,7 @@ dir <%export_namespace%> {
 		$execute store success score #success <%OBJECTIVES.I()%> run data modify storage aj:temp args set value $(args)
 
 		summon minecraft:item_display ~ ~ ~ { \
-			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_namespace)%>'], \
+			Tags:['<%TAGS.NEW()%>','<%TAGS.GLOBAL_ENTITY()%>','<%TAGS.GLOBAL_ROOT()%>','<%TAGS.PROJECT_ROOT(export_safe_namespace)%>'], \
 			teleport_duration: 0, \
 			interpolation_duration: <%interpolation_duration%>, \
 			Passengers:<%root_entity_passengers%>, \
@@ -138,7 +138,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => v.type === 'camera')) as camera {
-					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_namespace, camera.name)%>'], teleport_duration: 2}
+					summon item_display ~ ~ ~ {Tags:['<%TAGS.NEW()%>', '<%TAGS.GLOBAL_CAMERA()%>', '<%TAGS.PROJECT_CAMERA(export_safe_namespace)%>', '<%TAGS.PROJECT_CAMERA(export_namespace, camera.name)%>'], teleport_duration: 2}
 					execute as @e[type=item_display,tag=<%TAGS.NEW()%>,tag=<%TAGS.GLOBAL_CAMERA()%>,limit=1,distance=..0.01] run {
 						tag @s remove <%TAGS.NEW()%>
 
@@ -154,7 +154,7 @@ dir <%export_namespace%> {
 				}
 
 				REPEAT (Object.values(rig.nodes).filter(v => ['bone', 'text_display', 'item_display', 'block_display'].includes(v.type))) as bone {
-					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_namespace, bone.name)%>] run \
+					execute on vehicle on passengers if entity @s[tag=<%TAGS.PROJECT_NODE_NAMED(export_safe_namespace, bone.name)%>] run \
 						function *global/internal/gu/convert_uuid_array_to_string with entity @s
 					data modify entity @s data.bones.<%bone.type + '_' + bone.name%> set from storage aj:uuid main.out
 				}
@@ -208,7 +208,7 @@ dir <%export_namespace%> {
 		function as_own_locator_entities {
 			#ARGS: {command: string}
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/as_all_locators'}
 			}
@@ -227,12 +227,12 @@ dir <%export_namespace%> {
 	dir remove {
 		# Removes all instances of this rig from the world.
 		function all {
-			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run function *<%export_namespace%>/remove/this
+			execute as @e[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run function *<%export_namespace%>/remove/this
 		}
 		# Removes the rig this function is executed as.
 		function this {
 			IF (show_function_errors) {
-				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+				execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 					function *global/errors/function_not_executed_as_root_entity \
 						{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/remove/this'}
 			}
@@ -270,13 +270,13 @@ dir <%export_namespace%> {
 				dir <%variant.name%> {
 					function apply {
 						IF (show_function_errors) {
-							execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+							execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 								function *global/errors/function_not_executed_as_root_entity \
 									{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/variants/<%variant.name%>/apply'}
 						}
 						REPEAT (Object.values(rig.nodes)) as node {
 							IF (node.type === 'bone' && !variant.excluded_nodes.includes(node.uuid) && (variant.models[node.uuid] !== undefined || node.configs.variants[variant.uuid] !== undefined)) {
-								execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run {
+								execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run {
 									IF (variant.models[node.uuid] !== undefined) {
 										data modify entity @s item.components.minecraft:custom_model_data.strings[0] set value "<%variant.name%>"
 									}
@@ -299,12 +299,12 @@ dir <%export_namespace%> {
 
 	function set_default_pose {
 		# Changes the pose of the rig to the the default pose without interpolation
-		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_namespace)%>] run return run \
+		execute unless entity @s[type=item_display,tag=<%TAGS.PROJECT_ROOT(export_safe_namespace)%>] run return run \
 			function *global/errors/function_not_executed_as_root_entity \
 				{'export_namespace': '<%export_namespace%>', 'function_path': 'animated_java:<%export_namespace%>/set_default_pose'}
 		REPEAT (Object.values(rig.nodes)) as node {
 			IF (['bone', 'text_display', 'item_display', 'block_display'].includes(node.type)) {
-				execute on passengers if entity @s[tag=aj.<%export_namespace%>.bone.<%node.safe_name%>] run \
+				execute on passengers if entity @s[tag=aj.<%export_safe_namespace%>.bone.<%node.safe_name%>] run \
 					data merge entity @s {transformation: <%matrixToNbtFloatArray(node.default_transform.matrix).toString()%>, start_interpolation: -1}
 			}
 		}

--- a/src/systems/datapackCompiler/index.ts
+++ b/src/systems/datapackCompiler/index.ts
@@ -69,9 +69,9 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 		TAGS.GLOBAL_NODE(),
 		TAGS.GLOBAL_NODE_NAMED(node.safe_name),
 		// Project
-		TAGS.PROJECT_ENTITY(Project!.animated_java.export_namespace),
-		TAGS.PROJECT_NODE(Project!.animated_java.export_namespace),
-		TAGS.PROJECT_NODE_NAMED(Project!.animated_java.export_namespace, node.safe_name)
+		TAGS.PROJECT_ENTITY(Project!.animated_java.export_safe_namespace),
+		TAGS.PROJECT_NODE(Project!.animated_java.export_safe_namespace),
+		TAGS.PROJECT_NODE_NAMED(Project!.animated_java.export_safe_namespace, node.safe_name)
 	)
 
 	if (!node.parent) {
@@ -87,13 +87,13 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 				TAGS.GLOBAL_BONE_TREE_BONE(node.safe_name), // Tree includes self
 				// Project
 				TAGS.PROJECT_DISPLAY_NODE_NAMED(
-					Project!.animated_java.export_namespace,
+					Project!.animated_java.export_safe_namespace,
 					node.safe_name
 				),
-				TAGS.PROJECT_BONE(Project!.animated_java.export_namespace),
-				TAGS.PROJECT_BONE_NAMED(Project!.animated_java.export_namespace, node.safe_name),
-				TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_namespace, node.safe_name), // Tree includes self
-				TAGS.PROJECT_BONE_TREE_BONE(Project!.animated_java.export_namespace, node.safe_name) // Tree includes self
+				TAGS.PROJECT_BONE(Project!.animated_java.export_safe_namespace),
+				TAGS.PROJECT_BONE_NAMED(Project!.animated_java.export_safe_namespace, node.safe_name),
+				TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_safe_namespace, node.safe_name), // Tree includes self
+				TAGS.PROJECT_BONE_TREE_BONE(Project!.animated_java.export_safe_namespace, node.safe_name) // Tree includes self
 			)
 			if (!node.parent) {
 				// Nodes without parents are assumed to be root nodes
@@ -105,11 +105,11 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_CHILD_BONE(parentNames[0].name),
 					// Project
 					TAGS.PROJECT_BONE_CHILD(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					),
 					TAGS.PROJECT_BONE_CHILD_BONE(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					)
 				)
@@ -122,10 +122,10 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_TREE(name),
 					TAGS.GLOBAL_BONE_TREE_BONE(name),
 					// Project
-					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_namespace, name),
-					TAGS.PROJECT_BONE_DECENDANT_BONE(Project!.animated_java.export_namespace, name),
-					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_namespace, name),
-					TAGS.PROJECT_BONE_TREE_BONE(Project!.animated_java.export_namespace, name)
+					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_safe_namespace, name),
+					TAGS.PROJECT_BONE_DECENDANT_BONE(Project!.animated_java.export_safe_namespace, name),
+					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_safe_namespace, name),
+					TAGS.PROJECT_BONE_TREE_BONE(Project!.animated_java.export_safe_namespace, name)
 				)
 			}
 			break
@@ -137,12 +137,12 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 				TAGS.GLOBAL_ITEM_DISPLAY(),
 				// Project
 				TAGS.PROJECT_DISPLAY_NODE_NAMED(
-					Project!.animated_java.export_namespace,
+					Project!.animated_java.export_safe_namespace,
 					node.safe_name
 				),
-				TAGS.PROJECT_ITEM_DISPLAY(Project!.animated_java.export_namespace),
+				TAGS.PROJECT_ITEM_DISPLAY(Project!.animated_java.export_safe_namespace),
 				TAGS.PROJECT_ITEM_DISPLAY_NAMED(
-					Project!.animated_java.export_namespace,
+					Project!.animated_java.export_safe_namespace,
 					node.safe_name
 				)
 			)
@@ -156,11 +156,11 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_CHILD_ITEM_DISPLAY(parentNames[0].name),
 					// Project
 					TAGS.PROJECT_BONE_CHILD(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					),
 					TAGS.PROJECT_BONE_CHILD_ITEM_DISPLAY(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					)
 				)
@@ -172,12 +172,12 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_DECENDANT_ITEM_DISPLAY(name),
 					TAGS.GLOBAL_BONE_TREE(name),
 					// Project
-					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_namespace, name),
+					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_safe_namespace, name),
 					TAGS.PROJECT_BONE_DECENDANT_ITEM_DISPLAY(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						name
 					),
-					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_namespace, name)
+					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_safe_namespace, name)
 				)
 			}
 			break
@@ -189,12 +189,12 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 				TAGS.GLOBAL_BLOCK_DISPLAY(),
 				// Project
 				TAGS.PROJECT_DISPLAY_NODE_NAMED(
-					Project!.animated_java.export_namespace,
+					Project!.animated_java.export_safe_namespace,
 					node.safe_name
 				),
-				TAGS.PROJECT_BLOCK_DISPLAY(Project!.animated_java.export_namespace),
+				TAGS.PROJECT_BLOCK_DISPLAY(Project!.animated_java.export_safe_namespace),
 				TAGS.PROJECT_BLOCK_DISPLAY_NAMED(
-					Project!.animated_java.export_namespace,
+					Project!.animated_java.export_safe_namespace,
 					node.safe_name
 				)
 			)
@@ -208,11 +208,11 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_CHILD_BLOCK_DISPLAY(parentNames[0].name),
 					// Project
 					TAGS.PROJECT_BONE_CHILD(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					),
 					TAGS.PROJECT_BONE_CHILD_BLOCK_DISPLAY(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					)
 				)
@@ -224,12 +224,12 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_DECENDANT_BLOCK_DISPLAY(name),
 					TAGS.GLOBAL_BONE_TREE(name),
 					// Project
-					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_namespace, name),
+					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_safe_namespace, name),
 					TAGS.PROJECT_BONE_DECENDANT_BLOCK_DISPLAY(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						name
 					),
-					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_namespace, name)
+					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_safe_namespace, name)
 				)
 			}
 			break
@@ -241,12 +241,12 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 				TAGS.GLOBAL_TEXT_DISPLAY(),
 				// Project
 				TAGS.PROJECT_DISPLAY_NODE_NAMED(
-					Project!.animated_java.export_namespace,
+					Project!.animated_java.export_safe_namespace,
 					node.safe_name
 				),
-				TAGS.PROJECT_TEXT_DISPLAY(Project!.animated_java.export_namespace),
+				TAGS.PROJECT_TEXT_DISPLAY(Project!.animated_java.export_safe_namespace),
 				TAGS.PROJECT_TEXT_DISPLAY_NAMED(
-					Project!.animated_java.export_namespace,
+					Project!.animated_java.export_safe_namespace,
 					node.safe_name
 				)
 			)
@@ -260,11 +260,11 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_CHILD_TEXT_DISPLAY(parentNames[0].name),
 					// Project
 					TAGS.PROJECT_BONE_CHILD(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					),
 					TAGS.PROJECT_BONE_CHILD_TEXT_DISPLAY(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					)
 				)
@@ -276,12 +276,12 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_DECENDANT_TEXT_DISPLAY(name),
 					TAGS.GLOBAL_BONE_TREE(name),
 					// Project
-					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_namespace, name),
+					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_safe_namespace, name),
 					TAGS.PROJECT_BONE_DECENDANT_TEXT_DISPLAY(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						name
 					),
-					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_namespace, name)
+					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_safe_namespace, name)
 				)
 			}
 			break
@@ -291,8 +291,8 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 				// Global
 				TAGS.GLOBAL_LOCATOR(),
 				// Project
-				TAGS.PROJECT_LOCATOR(Project!.animated_java.export_namespace),
-				TAGS.PROJECT_LOCATOR_NAMED(Project!.animated_java.export_namespace, node.safe_name)
+				TAGS.PROJECT_LOCATOR(Project!.animated_java.export_safe_namespace),
+				TAGS.PROJECT_LOCATOR_NAMED(Project!.animated_java.export_safe_namespace, node.safe_name)
 			)
 			if (!node.parent) {
 				// Nodes without parents are assumed to be root nodes
@@ -304,11 +304,11 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_CHILD_LOCATOR(parentNames[0].name),
 					// Project
 					TAGS.PROJECT_BONE_CHILD(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					),
 					TAGS.PROJECT_BONE_CHILD_LOCATOR(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					)
 				)
@@ -320,12 +320,12 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_DECENDANT_LOCATOR(name),
 					TAGS.GLOBAL_BONE_TREE(name),
 					// Project
-					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_namespace, name),
+					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_safe_namespace, name),
 					TAGS.PROJECT_BONE_DECENDANT_LOCATOR(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						name
 					),
-					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_namespace, name)
+					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_safe_namespace, name)
 				)
 			}
 			break
@@ -335,8 +335,8 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 				// Global
 				TAGS.GLOBAL_CAMERA(),
 				// Project
-				TAGS.PROJECT_CAMERA(Project!.animated_java.export_namespace),
-				TAGS.PROJECT_CAMERA_NAMED(Project!.animated_java.export_namespace, node.safe_name)
+				TAGS.PROJECT_CAMERA(Project!.animated_java.export_safe_namespace),
+				TAGS.PROJECT_CAMERA_NAMED(Project!.animated_java.export_safe_namespace, node.safe_name)
 			)
 			if (!node.parent) {
 				// Nodes without parents are assumed to be root nodes
@@ -348,11 +348,11 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_CHILD_CAMERA(parentNames[0].name),
 					// Project
 					TAGS.PROJECT_BONE_CHILD(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					),
 					TAGS.PROJECT_BONE_CHILD_CAMERA(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						parentNames[0].name
 					)
 				)
@@ -364,12 +364,12 @@ function getNodeTags(node: AnyRenderedNode, rig: IRenderedRig): NbtList {
 					TAGS.GLOBAL_BONE_DECENDANT_CAMERA(name),
 					TAGS.GLOBAL_BONE_TREE(name),
 					// Project
-					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_namespace, name),
+					TAGS.PROJECT_BONE_DECENDANT(Project!.animated_java.export_safe_namespace, name),
 					TAGS.PROJECT_BONE_DECENDANT_CAMERA(
-						Project!.animated_java.export_namespace,
+						Project!.animated_java.export_safe_namespace,
 						name
 					),
-					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_namespace, name)
+					TAGS.PROJECT_BONE_TREE(Project!.animated_java.export_safe_namespace, name)
 				)
 			}
 			break
@@ -590,7 +590,7 @@ async function generateRootEntityPassengers(rig: IRenderedRig, rigHash: string) 
 				new NbtList([
 					new NbtString(TAGS.GLOBAL_NODE()),
 					new NbtString(TAGS.GLOBAL_DATA()),
-					new NbtString(TAGS.PROJECT_DATA(aj.export_namespace)),
+					new NbtString(TAGS.PROJECT_DATA(aj.export_safe_namespace)),
 				])
 			)
 			.set(
@@ -840,7 +840,7 @@ async function createAnimationStorage(rig: IRenderedRig, animations: IRenderedAn
 		let frames = new NbtCompound()
 		const addFrameDataCommand = () => {
 			const str = `data modify storage aj.${
-				Project!.animated_java.export_namespace
+				Project!.animated_java.export_safe_namespace
 			}:animations ${animation.safe_name} merge value ${frames.toString()}`
 			dataCommands.push(str)
 			frames = new NbtCompound()
@@ -1022,6 +1022,7 @@ export default async function compileDataPack(options: {
 
 	const variables = {
 		export_namespace: aj.export_namespace,
+		export_safe_namespace: aj.export_safe_namespace,
 		interpolation_duration: aj.interpolation_duration,
 		teleportation_duration: aj.teleportation_duration,
 		display_item: aj.display_item,

--- a/src/systems/resourcepackCompiler/1.20.4.ts
+++ b/src/systems/resourcepackCompiler/1.20.4.ts
@@ -1,5 +1,5 @@
 import { MAX_PROGRESS, PROGRESS, PROGRESS_DESCRIPTION } from '../../interface/dialog/exportProgress'
-import { isResourcePackPath, toSafeFuntionName } from '../../util/minecraftUtil'
+import { isResourcePackPath, toSafeFunctionName } from '../../util/minecraftUtil'
 import { TRANSPARENT_TEXTURE } from '../../variants'
 import { IntentionalExportError } from '../exporter'
 import { ITextureAtlas } from '../minecraft/textureAtlas'
@@ -198,7 +198,7 @@ export default async function compileResourcePack(options: {
 			throw new Error(`Texture ${texture.name} is missing it's image data.`)
 		}
 
-		let textureName = toSafeFuntionName(texture.name)
+		let textureName = toSafeFunctionName(texture.name)
 		if (!texture.name.endsWith('.png')) textureName += '.png'
 		exportedFiles.set(PathModule.join(textureExportFolder, textureName), image)
 		if (mcmeta !== undefined)

--- a/src/systems/resourcepackCompiler/1.21.2.ts
+++ b/src/systems/resourcepackCompiler/1.21.2.ts
@@ -1,5 +1,5 @@
 import { MAX_PROGRESS, PROGRESS, PROGRESS_DESCRIPTION } from '../../interface/dialog/exportProgress'
-import { isResourcePackPath, toSafeFuntionName } from '../../util/minecraftUtil'
+import { isResourcePackPath, toSafeFunctionName } from '../../util/minecraftUtil'
 import { TRANSPARENT_TEXTURE } from '../../variants'
 import { IntentionalExportError } from '../exporter'
 import { type ITextureAtlas } from '../minecraft/textureAtlas'
@@ -97,7 +97,7 @@ export default async function compileResourcePack(options: {
 			throw new Error(`Texture ${texture.name} is missing it's image data.`)
 		}
 
-		let textureName = toSafeFuntionName(texture.name)
+		let textureName = toSafeFunctionName(texture.name)
 		if (!texture.name.endsWith('.png')) textureName += '.png'
 		exportedFiles.set(PathModule.join(textureExportFolder, textureName), image)
 		if (mcmeta !== undefined)

--- a/src/systems/resourcepackCompiler/1.21.4.ts
+++ b/src/systems/resourcepackCompiler/1.21.4.ts
@@ -1,5 +1,5 @@
 import { MAX_PROGRESS, PROGRESS, PROGRESS_DESCRIPTION } from '../../interface/dialog/exportProgress'
-import { isResourcePackPath, toSafeFuntionName } from '../../util/minecraftUtil'
+import { isResourcePackPath, toSafeFunctionName } from '../../util/minecraftUtil'
 import { TRANSPARENT_TEXTURE, Variant } from '../../variants'
 import { IntentionalExportError } from '../exporter'
 import { IItemDefinition } from '../minecraft/itemDefinitions'
@@ -96,7 +96,7 @@ export default async function compileResourcePack(options: {
 			throw new Error(`Texture ${texture.name} is missing it's image data.`)
 		}
 
-		let textureName = toSafeFuntionName(texture.name)
+		let textureName = toSafeFunctionName(texture.name)
 		if (!texture.name.endsWith('.png')) textureName += '.png'
 		exportedFiles.set(PathModule.join(textureExportFolder, textureName), image)
 		if (mcmeta !== undefined)

--- a/src/systems/rigRenderer.ts
+++ b/src/systems/rigRenderer.ts
@@ -10,7 +10,7 @@ import { Alignment, TextDisplay } from '../outliner/textDisplay'
 import {
 	IMinecraftResourceLocation,
 	parseResourcePackPath,
-	toSafeFuntionName,
+	toSafeFunctionName,
 } from '../util/minecraftUtil'
 import { TRANSPARENT_TEXTURE, TRANSPARENT_TEXTURE_RESOURCE_LOCATION, Variant } from '../variants'
 import {
@@ -280,7 +280,7 @@ export function getTextureResourceLocation(texture: Texture, rig: IRenderedRig) 
 			return parsed
 		}
 	}
-	const path = PathModule.join(rig.texture_export_folder, toSafeFuntionName(texture.name))
+	const path = PathModule.join(rig.texture_export_folder, toSafeFunctionName(texture.name))
 	const parsed = parseResourcePackPath(path)
 	if (parsed) {
 		TEXTURE_RESOURCE_LOCATION_CACHE.set(texture.uuid, parsed)
@@ -333,7 +333,7 @@ function renderGroup(
 	const renderedBone: IRenderedNodes['Bone'] = {
 		type: 'bone',
 		name: group.name,
-		safe_name: toSafeFuntionName(group.name),
+		safe_name: toSafeFunctionName(group.name),
 		uuid: group.uuid,
 		parent: parentId,
 		bounding_box: getBoneBoundingBox(group),
@@ -442,7 +442,7 @@ function renderItemDisplay(display: VanillaItemDisplay, rig: IRenderedRig) {
 	const renderedBone: IRenderedNodes['ItemDisplay'] = {
 		type: 'item_display',
 		name: display.name,
-		safe_name: toSafeFuntionName(display.name),
+		safe_name: toSafeFunctionName(display.name),
 		uuid: display.uuid,
 		parent: parentId,
 		item: display.item,
@@ -470,7 +470,7 @@ function renderBlockDisplay(display: VanillaBlockDisplay, rig: IRenderedRig) {
 	const renderedBone: IRenderedNodes['BlockDisplay'] = {
 		type: 'block_display',
 		name: display.name,
-		safe_name: toSafeFuntionName(display.name),
+		safe_name: toSafeFunctionName(display.name),
 		uuid: display.uuid,
 		block: display.block,
 		parent: parentId,
@@ -497,7 +497,7 @@ function renderTextDisplay(display: TextDisplay, rig: IRenderedRig): INodeStruct
 	const renderedBone: IRenderedNodes['TextDisplay'] = {
 		type: 'text_display',
 		name: display.name,
-		safe_name: toSafeFuntionName(display.name),
+		safe_name: toSafeFunctionName(display.name),
 		uuid: display.uuid,
 		parent: parentId,
 		text: JsonText.fromString(display.text),
@@ -526,7 +526,7 @@ function renderLocator(locator: Locator, rig: IRenderedRig) {
 	const renderedLocator: IRenderedNodes['Locator'] = {
 		type: 'locator',
 		name: locator.name,
-		safe_name: toSafeFuntionName(locator.name),
+		safe_name: toSafeFunctionName(locator.name),
 		uuid: locator.uuid,
 		parent: parentId,
 		config: locator.config,
@@ -543,7 +543,7 @@ function renderCamera(camera: ICamera, rig: IRenderedRig) {
 	const renderedCamera: IRenderedNodes['Camera'] = {
 		type: 'camera',
 		name: camera.name,
-		safe_name: toSafeFuntionName(camera.name),
+		safe_name: toSafeFunctionName(camera.name),
 		uuid: camera.uuid,
 		parent: parentId,
 		config: camera.config,

--- a/src/util/minecraftUtil.ts
+++ b/src/util/minecraftUtil.ts
@@ -17,11 +17,15 @@ export interface IMinecraftResourceLocation {
 	type: string
 }
 
-export function toSafeFuntionName(name: string): string {
+export function toSafeFunctionName(name: string): string {
 	return name
 		.toLowerCase()
-		.replace(/[^a-z0-9_\\.]/g, '_')
+		.replace(/[^a-z0-9_\\./]/g, '_')
 		.replace(/_+/g, '_')
+}
+
+export function toSafeTagName(name: string): string {
+	return toSafeFunctionName(name).replace(/\//g, '.')
 }
 
 /**

--- a/src/variants.ts
+++ b/src/variants.ts
@@ -2,7 +2,7 @@ import { IBlueprintVariantJSON } from './blueprintFormat'
 import { PACKAGE } from './constants'
 import { events } from './util/events'
 import TransparentTexture from './assets/transparent.png'
-import { toSafeFuntionName } from './util/minecraftUtil'
+import { toSafeFunctionName } from './util/minecraftUtil'
 
 const OLD_PROJECT = Project
 // @ts-ignore
@@ -218,7 +218,7 @@ export class Variant {
 	}
 
 	public static makeNameUnique(variant: Variant, name: string): string {
-		name = toSafeFuntionName(name)
+		name = toSafeFunctionName(name)
 		if (!Variant.all.some(v => v !== variant && v.name === name)) {
 			return name
 		}


### PR DESCRIPTION
Allows forward slashes to be present in `export_namespace`, so that when exported, the data is exported to a subfolder. This is accomplished by changing all `/` to a `.` in required contexts.

I should note that I have never worked with TypeScript, Svelte, or MC-Build prior to this, so I apologize if my code is messy. My friend (to whom this was made for) tested it without any problems caused by these changes on her end. I can't make any guarantees about edge cases, though, due to my unfamiliarity.