### PR TITLE
Re-enable plugin export mode

### DIFF
--- a/src/systems/exporter.ts
+++ b/src/systems/exporter.ts
@@ -12,6 +12,7 @@ import compileDataPack from './datapackCompiler'
 import resourcepackCompiler from './resourcepackCompiler'
 import { hashRig, renderRig } from './rigRenderer'
 import { isCubeValid } from './util'
+import { exportJSON } from './jsonCompiler'
 
 export class IntentionalExportError extends Error {}
 
@@ -124,16 +125,15 @@ async function actuallyExportProject(forceSave = true) {
 			modelExportFolder,
 		})
 
-		// if (aj.enable_plugin_mode) {
-		// 	exportJSON({
-		// 		rig,
-		// 		animations,
-		// 		displayItemPath,
-		// 		textureExportFolder,
-		// 		modelExportFolder,
-		// 	})
-		// } else {
-		if (aj.data_pack_export_mode !== 'none') {
+		if (aj.enable_plugin_mode) {
+			exportJSON({
+				rig,
+				animations,
+				displayItemPath,
+				textureExportFolder,
+				modelExportFolder,
+			})
+		} else if (aj.data_pack_export_mode !== 'none') {
 			await compileDataPack(aj.target_minecraft_versions, {
 				rig,
 				animations,


### PR DESCRIPTION
Hey there!

I was playing around with the plugin mode schema, and noticed it wouldn't actually export as a json despite being configured to do so.
The json export option seems to have been commented out on 13-03-2025 while adding support for multi-version resourcepacks, and I couldn't find any mention of it being intentionally disabled in the discord.

This PR simply reverts the old behaviour, assuming it was left disabled by accident.

This would also address this issue: https://github.com/Animated-Java/animated-java/issues/424
Which is caused by the resource pack export pipeline being triggered without having the base path for it set (because the UI options don't exist for it in plugin mode)